### PR TITLE
Release 0.15.1-a1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To install a specific branch use the @branch syntax
     $ pip install git+https://github.com/SPOpenSource/edgeconnect-python@<branch_name>
     ...
     # Install the Development branch
-    $ pip install git+https://github.com/SPOpenSource/edgeconnect-python@Development
+    $ pip install git+https://github.com/SPOpenSource/edgeconnect-python@development
     ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ is underway to continue to add further functions.
 
 ### Python Version
 
-> **Note:** Requires Python 3.9.0+ (due to PEP585 type-hinting e.g. ``def my_func(var1 = list[str]``)
+> **Note:** Requires Python 3.7+
 
-Once Python 3.9 is installed on the system, it's recommended to use a
+Once Python 3.7+ is installed on the system, it's recommended to use a
 virtual environment to install the package to.
 
 In the directory you'd like to write your project/script, setup a python
-virtual environment specifically with python3.9 and activate it. This
+virtual environment with the desired python version and activate it. This
 is important if you have other versions of python installed on your
 system.
 
@@ -29,34 +29,25 @@ system.
 
     :~$ python3.9 -m venv my_new_project
     :~$ source my_new_project/bin/activate
-    (my_new_project) :~$ python3 --version
-    Python 3.9.0+
+    (my_new_project) :~$ python --version
+    Python 3.9.13
 ```
 
-Now you can install the package and run your python code
+Now you are ready to install the package and run your python code.
 
-```bash
-
-    (my_new_project) :~$ pip install git+https://github.com/SPOpenSource/edgeconnect-python
-    ...
-    (my_new_project) :~$ pip list
-    Package               Version
-    --------------------- --------------------------------
-    certifi               2020.12.5
-    chardet               4.0.0
-    idna                  2.10
-    pip                   20.0.2
-    pkg-resources         0.0.0
-    requests              2.25.1
-    setuptools            44.0.0
-    pyedgeconnect         0.13.0a2.dev1+g45fd843.d20210428
-    urllib3               1.26.4
-```
+> **Note:** Going forward, these commands assume you're within a Python 3.7+ venv, or Python 3.7+ is the exclusive Python version installed in regard to referencing the use of ``pip``. If that is not the case, you can specifically append ``python3.x -m`` ahead of the ``pip install ...``
 
 ### Install from PyPI
 
 ```bash
-    pip install pyedgeconnect
+    $ pip install pyedgeconnect
+    ...
+    $ pip list
+    Package                       Version
+    ----------------------------- --------------------------------
+    ...                           ...
+    pyedgeconnect                 x.y.z
+    ...                           ...
 ```
 
 ### Install from GitHub
@@ -64,16 +55,25 @@ Now you can install the package and run your python code
 To install the most recent version of pyedgeconnect, open an
 interactive shell and run:
 
-> **Note:** These commands assume you're within a Python 3.9 venv, or Python 3.9 is the exclusive Python version installed in regard to referencing the use of ``pip``. If that is not the case, you can specifically append ``python3.9 -m`` ahead of the ``pip install ...``
-
 ```bash
-    pip install git+https://github.com/SPOpenSource/edgeconnect-python
+    $ pip install git+https://github.com/SPOpenSource/edgeconnect-python
+    ...
+    $ pip list
+    Package                       Version
+    ----------------------------- --------------------------------
+    ...                           ...
+    pyedgeconnect                 x.y.z
+    ...                           ...
 ```
 
 To install a specific branch use the @branch syntax
 
 ```bash
-    pip install git+https://github.com/SPOpenSource/edgeconnect-python@<branch_name>
+    $ pip install git+https://github.com/SPOpenSource/edgeconnect-python@<branch_name>
+    ...
+    # Install the Development branch
+    $ pip install git+https://github.com/SPOpenSource/edgeconnect-python@Development
+    ...
 ```
 
 ### Install dev options
@@ -88,7 +88,7 @@ following syntax:
 ```bash
     $ pip install pyedgeconnect[dev]
     or
-    $ pip install -e git+https://github.com/SPOpenSource/edgeconnect-python#egg=pyedgeconnect[dev]
+    $ pip install git+https://github.com/SPOpenSource/edgeconnect-python#egg=pyedgeconnect[dev]
 ```
 
 ## Docs

--- a/_version.py
+++ b/_version.py
@@ -1,1 +1,1 @@
-version = "0.15.0a2.dev0"
+version = "0.15.1a1.dev0"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ author = "Zach Camara"
 # Main version number
 version = "0.15"
 # The full version, including alpha/beta/rc tags
-release = "0.15.0-a1"
+release = "0.15.1-a1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -7,14 +7,13 @@ Python Version
 
 .. note::
 
-    Requires Python 3.9.0+ (due to PEP585 type-hinting e.g.
-    ``def my_func(var1 = list[str]``)
+    Requires Python 3.7+
 
-Once Python 3.9 is installed on the system, it's recommended to use a
+Once Python 3.7+ is installed on the system, it's recommended to use a
 virtual environment to install the package to.
 
 In the directory you'd like to write your project/script, setup a python
-virtual environment specifically with python3.9 and activate it. This
+virtual environment with the desired python version and activate it. This
 is important if you have other versions of python installed on your
 system.
 
@@ -23,26 +22,18 @@ system.
     :~$ python3.9 -m venv my_new_project
     :~$ source my_new_project/bin/activate
     (my_new_project) :~$ python3 --version
-    Python 3.9.0+
+    Python 3.9.13
 
-Now you can install the package and run your python code
+Now you are ready to install the package and run your python code.
 
-.. code:: bash
+.. note::
 
-    (my_new_project) :~$ pip install git+https://github.com/SPOpenSource/edgeconnect-python
-    ...
-    (my_new_project) :~$ pip list
-    Package               Version
-    --------------------- --------------------------------
-    certifi               2020.12.5
-    chardet               4.0.0
-    idna                  2.10
-    pip                   20.0.2
-    pkg-resources         0.0.0
-    requests              2.25.1
-    setuptools            44.0.0
-    pyedgeconnect         0.13.0a1.dev1+g45fd843.d20210428
-    urllib3               1.26.4
+    Going forward, these commands assume you're within a Python 3.7+ venv, or Python 3.7+
+    is the exclusive Python version installed in regard to referencing
+    the use of ``pip``.
+
+    If that is not the case, you can specifically append
+    ``python3.x -m`` ahead of the ``pip install ...``
 
 Install from PyPI
 -------------------
@@ -50,7 +41,13 @@ Install from PyPI
 .. code:: bash
 
     $ pip install pyedgeconnect
-
+    ...
+    $ pip list
+    Package                       Version
+    ----------------------------- --------------------------------
+    ...                           ...
+    pyedgeconnect                 x.y.z
+    ...                           ...
 
 Install from GitHub
 -------------------
@@ -58,26 +55,24 @@ Install from GitHub
 To install the most recent version of pyedgeconnect, open an
 interactive shell and run:
 
-.. note::
+.. code:: bash
 
-    These commands assume you're within a Python 3.9 venv, or Python 3.9
-    is the exclusive Python version installed in regard to referencing
-    the use of ``pip``.
-
-    If that is not the case, you can specifically append
-    ``python3.9 -m`` ahead of the ``pip install ...``
-
-.. code:: python
-
-    pip install git+https://github.com/SPOpenSource/edgeconnect-python
+    $ pip install git+https://github.com/SPOpenSource/edgeconnect-python
+    ...
+    $ pip list
+    Package                       Version
+    ----------------------------- --------------------------------
+    ...                           ...
+    pyedgeconnect                 x.y.z
+    ...                           ...
 
 To install a specific branch use the @branch syntax
 
-.. code:: python
+.. code:: bash
 
-    pip install git+https://github.com/SPOpenSource/edgeconnect-python@<branch_name>
-
-
+    $ pip install git+https://github.com/SPOpenSource/edgeconnect-python@<branch_name>
+    # Install the Development branch
+    $ pip install git+https://github.com/SPOpenSource/edgeconnect-python@Development
 
 Build Documentation Locally
 ---------------------------
@@ -87,8 +82,8 @@ to include sphinx and related packages, then in the docs directory run ``make ht
 
 .. code:: bash
 
-    git clone https://github.com/SPOpenSource/edgeconnect-python.git
-    cd edgeconnect-python
-    pip install .[dev]
-    cd docs
-    make html
+    $ git clone https://github.com/SPOpenSource/edgeconnect-python.git
+    $ cd edgeconnect-python
+    $ pip install .[dev]
+    $ cd docs
+    $ make html

--- a/docs/source/release-notes/0.15.1-a1.rst
+++ b/docs/source/release-notes/0.15.1-a1.rst
@@ -1,0 +1,54 @@
+0.15.1-a1 -- 2022-06-23
+-----------------------
+
+
+🚀 Features
+~~~~~~~~~~~~~
+
+**Backwards compatability**: Introduced support back to Python 3.7
+
+
+Added the following EdgeConnect functions from Swagger:
+
+from .ecos._disk_usage
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_disk_usage`
+
+from .ecos._dns
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_dns_config`
+  - :func:`~pyedgeconnect.EdgeConnect.set_appliance_dns_config`
+
+from .ecos._memory
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_memory`
+
+from .ecos._statistics
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_stats_minute_range`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_stats_minute_file`
+
+from .ecos._time
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_time`
+
+
+🐛 Bug Fixes
+~~~~~~~~~~~~~~
+
+- `#4 <https://github.com/SPOpenSource/edgeconnect-python/issues/4>`_ -
+  :func:`~pyedgeconnect.Orchestrator.get_all_users` was using POST
+  instead of GET
+- `#6 <https://github.com/SPOpenSource/edgeconnect-python/issues/6>`_ -
+  :func:`~pyedgeconnect.Orchestrator.update_appliance_access_group`
+  remove default values for appliance_groups and appliance_regions
+- `#7 <https://github.com/SPOpenSource/edgeconnect-python/issues/7>`_ -
+  :func:`~pyedgeconnect.Orchestrator.get_timeseries_stats_tunnel_single_appliance`
+  update tunnel_name query in URL to tunnelName
+
+
+🐛 Known Issues
+~~~~~~~~~~~~~~~
+
+.. warning::
+
+  The following two functions for the _ip_objects submodule exprience
+  errors at this time. These function do work in the Orchestrator UI:
+
+  - :func:`~pyedgeconnect.Orchestrator.bulk_upload_address_group`
+  - :func:`~pyedgeconnect.Orchestrator.bulk_upload_service_group`

--- a/docs/source/release-notes/index.rst
+++ b/docs/source/release-notes/index.rst
@@ -8,6 +8,7 @@ All of the release notes for pyedgeconnect are organized below
 ==================
 
 .. toctree::
+    0.15.1-a1
     0.15.0-a1
     0.14.0-a2
     0.14.0-a1

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1328,6 +1328,7 @@ class EdgeConnect(HttpCommon):
             self.logger.addHandler(self.console_handler)
 
     # Imported methods
+    from .ecos._dns import get_appliance_dns_config, set_appliance_dns_config
     from .ecos._gms import assign_orchestrator, get_orchestrator
     from .ecos._interfaces import get_appliance_interfaces
     from .ecos._license import is_reboot_required

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1328,6 +1328,7 @@ class EdgeConnect(HttpCommon):
             self.logger.addHandler(self.console_handler)
 
     # Imported methods
+    from .ecos._disk_usage import get_appliance_disk_usage
     from .ecos._dns import get_appliance_dns_config, set_appliance_dns_config
     from .ecos._gms import assign_orchestrator, get_orchestrator
     from .ecos._interfaces import get_appliance_interfaces

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1339,3 +1339,7 @@ class EdgeConnect(HttpCommon):
     from .ecos._reboot import request_reboot
     from .ecos._save_changes import save_changes
     from .ecos._sp_portal import register_sp_portal, register_sp_portal_status
+    from .ecos._statistics import (
+        get_appliance_stats_minute_file,
+        get_appliance_stats_minute_range,
+    )

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1345,3 +1345,4 @@ class EdgeConnect(HttpCommon):
         get_appliance_stats_minute_file,
         get_appliance_stats_minute_range,
     )
+    from .ecos._time import get_appliance_time

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1332,6 +1332,7 @@ class EdgeConnect(HttpCommon):
     from .ecos._interfaces import get_appliance_interfaces
     from .ecos._license import is_reboot_required
     from .ecos._login import login, logout
+    from .ecos._memory import get_appliance_memory
     from .ecos._network_interfaces import (
         get_appliance_network_interfaces,
         modify_network_interfaces,

--- a/pyedgeconnect/ecos/_disk_usage.py
+++ b/pyedgeconnect/ecos/_disk_usage.py
@@ -1,0 +1,32 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# diskUsage : Available disk space
+
+
+def get_appliance_disk_usage(
+    self,
+) -> dict:
+    """Get the disk usage of the appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - diskUsage
+          - GET
+          - /diskUsage
+
+    :return: Returns dictionary of current appliance disk usage \n
+        * keyword **<directory name>** (`dict`): Directory disk
+          utilization, e.g. ``/`` or ``/dev`` etc. \n
+            * keyword **1k-blocks** (`int`): The number of 1k-blocks
+            * keyword **used** (`int`): Size of used space, KB
+            * keyword **available** (`int`): Size of available space, KB
+            * keyword **usedpercent** (`int`): Percent of used space
+            * keyword **filesystem** (`str`): Name of the filesystem
+    :rtype: dict
+    """
+    return self._get("/diskUsage")

--- a/pyedgeconnect/ecos/_dns.py
+++ b/pyedgeconnect/ecos/_dns.py
@@ -1,0 +1,172 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# dns : DNS server and domain
+
+
+def get_appliance_dns_config(
+    self,
+) -> dict:
+    """Get the current DNS IP address and domain names configured for
+    your appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - dns
+          - GET
+          - /resolver
+
+    :return: Returns dictionary of current appliance dns configuration\n
+        * keyword **domain_search*** (`dict`): Domain search settings \n
+            * keyword **<Order of search 1-6>** (`dict`): \n
+                * keyword **self** (`int`): Order of Domain Name, which
+                  should be the same as this entry's key
+                * keyword **domainname** (`str`): Search Domain
+        * keyword **nameserver*** (`dict`): Name server settings \n
+            * keyword **1** (`dict`): Primary name server\n
+                * keyword **self** (`int`): Order of Name Server, which
+                  should be the same as this entry's key
+                * keyword **address** (`str`): IP of DNS Server
+                * keyword **vrf_id** (`int`): Segment ID, which default
+                  value is 0
+                * keyword **srcinf** (`str`): Source Interface, which
+                  default value is any
+            * keyword **2** (`dict`): Secondary name server\n
+                * keyword **self** (`int`): Order of Name Server, which
+                  should be the same as this entry's key
+                * keyword **address** (`str`): IP of DNS Server
+                * keyword **vrf_id** (`int`): Segment ID, which default
+                  value is 0
+                * keyword **srcinf** (`str`): Source Interface, which
+                    default value is any
+            * keyword **3** (`dict`): Tertiary name server\n
+                * keyword **self** (`int`): Order of Name Server, which
+                  should be the same as this entry's key
+                * keyword **address** (`str`): IP of DNS Server
+                * keyword **vrf_id** (`int`): Segment ID, which default
+                  value is 0
+                * keyword **srcinf** (`str`): Source Interface, which
+                  default value is any
+    :rtype: dict
+    """
+    return self._get("/resolver")
+
+
+def set_appliance_dns_config(
+    self,
+    domain_search_settings: dict,
+    primary_ns_address: str,
+    primary_ns_vrf_id: int,
+    primary_ns_source_interface: str,
+    secondary_ns_address: str,
+    secondary_ns_vrf_id: int,
+    secondary_ns_source_interface: str,
+    tertiary_ns_address: str,
+    tertiary_ns_vrf_id: int,
+    tertiary_ns_source_interface: str,
+) -> dict:
+    """Get the current DNS IP address and domain names configured for
+    your appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - dns
+          - POST
+          - /resolver
+
+    Example:
+
+    .. code-block:: python
+
+        domain_search_settings = {
+            "1": {
+                "self": 1,
+                "domainname": "my.search.domain",
+            },
+        }
+
+        ec.set_appliance_dns_config(
+            domain_search_settings = domain_search_settings,
+            primary_ns_address = "192.0.2.100",
+            primary_ns_vrf_id = 0,
+            primary_ns_source_interface = "mgmt0",
+            secondary_ns_address = "192.0.2.200",
+            secondary_ns_vrf_id = 0,
+            secondary_ns_source_interface = "",
+            tertiary_ns_address = "",
+            tertiary_ns_vrf_id = 0,
+            tertiary_ns_source_interface = "",
+        )
+
+    :param domain_search_settings: Domain search settings dictionary
+        object. Up to 6 can be specified, each with a key of the
+        order they should be applied (1-6). Example below \n
+        * keyword **1** (`dict`): Search domain object \n
+            * keyword **self** (`int`): Numeric ID, same as key
+            * keyword **domainname** (`str`): Search domain,
+              e.g. ``my.search.domain``
+    :type domain_search_settings: dict
+    :param primary_ns_address: Primary DNS server IP address
+    :type primary_ns_address: str
+    :param primary_ns_vrf_id: Segment/VRF ID to reach Primary DNS
+        server, e.g. ``0`` for Default VRF
+    :type primary_ns_vrf_id: int
+    :param primary_ns_source_interface: Interface to reach Primary
+        DNS server, e.g. ``mgmt0`` or ``lan0``
+    :type primary_ns_source_interface: str
+    :param secondary_ns_address: Secondary DNS server IP address
+    :type secondary_ns_address: str
+    :param secondary_ns_vrf_id: Segment/VRF ID to reach Secondary
+        DNS server, e.g. ``0`` for Default VRF
+    :type secondary_ns_vrf_id: int
+    :param secondary_ns_source_interface: Interface to reach
+        Secondary DNS server, e.g. ``mgmt0`` or ``lan0``
+    :type secondary_ns_source_interface: str
+    :param tertiary_ns_address: Tertiary DNS server IP address
+    :type tertiary_ns_address: str
+    :param tertiary_ns_vrf_id: Segment/VRF ID to reach Tertiary DNS
+        server, e.g. ``0`` for Default VRF
+    :type tertiary_ns_vrf_id: int
+    :param tertiary_ns_source_interface: Interface to reach Tertiary
+        DNS server, e.g. ``mgmt0`` or ``lan0``
+    :type tertiary_ns_source_interface: str
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    data = {
+        "domain_search": domain_search_settings,
+        "nameserver": {
+            "1": {
+                "self": 1,
+                "address": primary_ns_address,
+                "vrf_id": primary_ns_vrf_id,
+                "srcinf": primary_ns_source_interface,
+            },
+            "2": {
+                "self": 2,
+                "address": secondary_ns_address,
+                "vrf_id": secondary_ns_vrf_id,
+                "srcinf": secondary_ns_source_interface,
+            },
+            "3": {
+                "self": 3,
+                "address": tertiary_ns_address,
+                "vrf_id": tertiary_ns_vrf_id,
+                "srcinf": tertiary_ns_source_interface,
+            },
+        },
+    }
+
+    return self._post(
+        "/resolver",
+        data=data,
+        return_type="bool",
+    )

--- a/pyedgeconnect/ecos/_dns.py
+++ b/pyedgeconnect/ecos/_dns.py
@@ -21,12 +21,12 @@ def get_appliance_dns_config(
           - /resolver
 
     :return: Returns dictionary of current appliance dns configuration\n
-        * keyword **domain_search*** (`dict`): Domain search settings \n
+        * keyword **domain_search** (`dict`): Domain search settings \n
             * keyword **<Order of search 1-6>** (`dict`): \n
                 * keyword **self** (`int`): Order of Domain Name, which
                   should be the same as this entry's key
                 * keyword **domainname** (`str`): Search Domain
-        * keyword **nameserver*** (`dict`): Name server settings \n
+        * keyword **nameserver** (`dict`): Name server settings \n
             * keyword **1** (`dict`): Primary name server\n
                 * keyword **self** (`int`): Order of Name Server, which
                   should be the same as this entry's key

--- a/pyedgeconnect/ecos/_memory.py
+++ b/pyedgeconnect/ecos/_memory.py
@@ -1,0 +1,34 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# memory : Get memory related information
+
+
+def get_appliance_memory(
+    self,
+) -> dict:
+    """Get appliance memory related information
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - memory
+          - GET
+          - /memory
+
+    :return: Returns dictionary of current memory utilization on
+        appliance, all units in bytes \n
+        * keyword **total*** (`int`): Total memory
+        * keyword **free*** (`int`): Free memory
+        * keyword **buffers*** (`int`): Buffers memory
+        * keyword **cached*** (`int`): Cached memory
+        * keyword **used*** (`int`): Used memory
+        * keyword **swapTotal*** (`int`): Swap total memory
+        * keyword **swapFree*** (`int`): Swap free memory
+        * keyword **swapUsed*** (`int`): Swap used memory
+    :rtype: dict
+    """
+    return self._get("/memory")

--- a/pyedgeconnect/ecos/_memory.py
+++ b/pyedgeconnect/ecos/_memory.py
@@ -21,14 +21,14 @@ def get_appliance_memory(
 
     :return: Returns dictionary of current memory utilization on
         appliance, all units in bytes \n
-        * keyword **total*** (`int`): Total memory
-        * keyword **free*** (`int`): Free memory
-        * keyword **buffers*** (`int`): Buffers memory
-        * keyword **cached*** (`int`): Cached memory
-        * keyword **used*** (`int`): Used memory
-        * keyword **swapTotal*** (`int`): Swap total memory
-        * keyword **swapFree*** (`int`): Swap free memory
-        * keyword **swapUsed*** (`int`): Swap used memory
+        * keyword **total** (`int`): Total memory
+        * keyword **free** (`int`): Free memory
+        * keyword **buffers** (`int`): Buffers memory
+        * keyword **cached** (`int`): Cached memory
+        * keyword **used** (`int`): Used memory
+        * keyword **swapTotal** (`int`): Swap total memory
+        * keyword **swapFree** (`int`): Swap free memory
+        * keyword **swapUsed** (`int`): Swap used memory
     :rtype: dict
     """
     return self._get("/memory")

--- a/pyedgeconnect/ecos/_statistics.py
+++ b/pyedgeconnect/ecos/_statistics.py
@@ -27,9 +27,9 @@ def get_appliance_stats_minute_range(self) -> dict:
 
     :return: Dictionary of newest and oldest minute stat times \n
         * keyword **newest** (`int`): Epoch seconds timestamp of latest
-            available appliance minute data
+          available appliance minute data
         * keyword **oldest** (`int`): Epoch seconds timestamp of oldest
-            available appliance minute data
+          available appliance minute data
     :rtype: dict
     """
     return self._get("/stats/minuteRange")

--- a/pyedgeconnect/ecos/_statistics.py
+++ b/pyedgeconnect/ecos/_statistics.py
@@ -1,0 +1,84 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# statistics : Get statistics related information
+
+
+def get_appliance_stats_minute_range(self) -> dict:
+    """Get the oldest minute and latest minute for which per minute
+    statistics are available
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - statistics
+          - GET
+          - /stats/minuteRange
+
+    Appliance stores statistics for each minute into a file of the
+    format: st2-{minute}.tgz. Time is the minute boundary expressed in
+    seconds since Jan 1, 1970. This API returns the newest and oldest
+    minute timestamps and users can call /stats/minuteStats/:file API to
+    retrieve the actual stats. For example:
+    GET /stats/minuteStats/st2-1428356220.tgz
+
+    :return: Dictionary of newest and oldest minute stat times \n
+        * keyword **newest** (`int`): Epoch seconds timestamp of latest
+            available appliance minute data
+        * keyword **oldest** (`int`): Epoch seconds timestamp of oldest
+            available appliance minute data
+    :rtype: dict
+    """
+    return self._get("/stats/minuteRange")
+
+
+def get_appliance_stats_minute_file(
+    self,
+    file: str,
+) -> dict:
+    """Get specific minute statistics file
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - statistics
+          - GET
+          - /stats/minuteRange
+
+    Appliance stores statistics for each minute into a file of the
+    format: st2-{minute}.tgz. Time is the minute boundary expressed in
+    seconds since Jan 1, 1970. For example:
+    GET /stats/minuteStats/st2-1428356220.tgz
+    Each file is tar and gzip archive of a number of csv files. Each csv
+    file has a header which describes the statistics contained in the
+    file.
+
+    .. code:: python
+        import tarfile
+        from pyedgeconnect import EdgeConnect
+        ec = EdgeConnect(ec_ip)
+        ec.login(ec_user,ec_pw)
+        stat = ec.get_appliance_stats_minute_file(st2-1428356220.tgz)
+        ec.logout()
+        if stat.status_code==200:
+            with open("stats.tgz",'wb') as stat_file:
+                for chunk in stat:
+                    stat_file.write(chunk)
+        tar = tarfile.open("stats.tgz")
+        tar.extractall()
+
+    :param file: Filename of statistics file to download from applinace
+    :type file: str
+    :return: Download tgz file as part of full response data \n
+    :rtype: `requests.Response` object
+    """
+    return self._get(
+        f"/stats/minuteStats/{file}",
+        return_type="full_response",
+    )

--- a/pyedgeconnect/ecos/_statistics.py
+++ b/pyedgeconnect/ecos/_statistics.py
@@ -59,7 +59,8 @@ def get_appliance_stats_minute_file(
     file has a header which describes the statistics contained in the
     file.
 
-    .. code:: python
+    .. code-block:: python
+
         import tarfile
         from pyedgeconnect import EdgeConnect
         ec = EdgeConnect(ec_ip)

--- a/pyedgeconnect/ecos/_time.py
+++ b/pyedgeconnect/ecos/_time.py
@@ -1,0 +1,28 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# time : Current time
+
+
+def get_appliance_time(
+    self,
+) -> dict:
+    """Get the current time on the appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - time
+          - GET
+          - /time
+
+    :return: Returns dictionary of current appliance time \n
+        * keyword **current** (`int`): Current unix epoch time in
+          milliseconds
+        * keyword **gmtOffset** (`int`): Hours offset from GMT
+    :rtype: dict
+    """
+    return self._get("/time")

--- a/pyedgeconnect/orch/_aggregate_stats.py
+++ b/pyedgeconnect/orch/_aggregate_stats.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # aggregateStats : ECOS aggregate statistics
+from __future__ import annotations
 
 
 def get_aggregate_stats_tunnels(
@@ -644,11 +645,9 @@ def get_aggregate_stats_applications(
         parameters
     :rtype: dict
     """
-    path = (
-        "/stats/aggregate/application2?"
-        + "startTime={}&endTime={}".format(
-            start_time, end_time,
-        )
+    path = "/stats/aggregate/application2?" + "startTime={}&endTime={}".format(
+        start_time,
+        end_time,
     )
 
     if group_pk is not None:
@@ -717,11 +716,9 @@ def get_aggregate_stats_applications_ne_pk_list(
         parameters
     :rtype: dict
     """
-    path = (
-        "/stats/aggregate/application2?"
-        + "startTime={}&endTime={}".format(
-            start_time, end_time,
-        )
+    path = "/stats/aggregate/application2?" + "startTime={}&endTime={}".format(
+        start_time,
+        end_time,
     )
 
     if application is not None:
@@ -791,7 +788,9 @@ def get_aggregate_stats_applications_single_appliance(
     path = (
         "/stats/aggregate/application2/"
         + "{}?startTime={}&endTime={}".format(
-            ne_pk, start_time, end_time,
+            ne_pk,
+            start_time,
+            end_time,
         )
     )
 
@@ -1321,7 +1320,7 @@ def get_aggregate_stats_flows_single_appliance(
     traffic_class: int = None,
     flow: str = None,
     ip: str = None,
-    data_format: str = None
+    data_format: str = None,
 ) -> dict:
     """Get aggregate flow stats data for a single appliance filter by
     query parameters
@@ -1745,7 +1744,8 @@ def get_aggregate_stats_dns_ne_pk_list(
     :rtype: dict
     """
     path = "/stats/aggregate/dns?startTime={}&endTime={}".format(
-        start_time, end_time,
+        start_time,
+        end_time,
     )
 
     if is_source is not None:
@@ -1826,7 +1826,9 @@ def get_aggregate_stats_dns_single_appliance(
     :rtype: dict
     """
     path = "/stats/aggregate/dns/{}?startTime={}&endTime={}".format(
-        ne_pk, start_time, end_time,
+        ne_pk,
+        start_time,
+        end_time,
     )
 
     if is_source is not None:
@@ -1905,7 +1907,9 @@ def get_aggregate_stats_ports_single_appliance(
     :rtype: dict
     """
     path = "/stats/aggregate/ports/{}?startTime={}&endTime={}".format(
-        ne_pk, start_time, end_time,
+        ne_pk,
+        start_time,
+        end_time,
     )
 
     if is_source is not None:
@@ -1986,7 +1990,8 @@ def get_aggregate_stats_ports(
     :rtype: dict
     """
     path = "/stats/aggregate/ports?startTime={}&endTime={}".format(
-        start_time, end_time,
+        start_time,
+        end_time,
     )
 
     if is_source is not None:
@@ -2069,7 +2074,8 @@ def get_aggregate_stats_ports_ne_pk_list(
     :rtype: dict
     """
     path = "/stats/aggregate/ports?startTime={}&endTime={}".format(
-        start_time, end_time,
+        start_time,
+        end_time,
     )
 
     if is_source is not None:
@@ -2136,7 +2142,8 @@ def get_aggregate_stats_top_talkers(
     :rtype: dict
     """
     path = "/stats/aggregate/topTalkers?startTime={}&endTime={}".format(
-        start_time, end_time,
+        start_time,
+        end_time,
     )
 
     if top is not None:
@@ -2194,7 +2201,8 @@ def get_aggregate_stats_top_talkers_ne_pk_list(
     :rtype: dict
     """
     path = "/stats/aggregate/topTalkers?startTime={}&endTime={}".format(
-        start_time, end_time,
+        start_time,
+        end_time,
     )
 
     if top is not None:
@@ -2244,7 +2252,9 @@ def get_aggregate_stats_top_talkers_single_appliance(
     :rtype: dict
     """
     path = "/stats/aggregate/topTalkers/{}?startTime={}&endTime={}".format(
-        ne_pk, start_time, end_time,
+        ne_pk,
+        start_time,
+        end_time,
     )
 
     if top is not None:
@@ -2290,7 +2300,9 @@ def get_aggregate_stats_top_talkers_split_single_appliance(
     path = (
         "/stats/aggregate/topTalkers/split/"
         + "{}?startTime={}&endTime={}".format(
-            ne_pk, start_time, end_time,
+            ne_pk,
+            start_time,
+            end_time,
         )
     )
 
@@ -2343,7 +2355,8 @@ def get_aggregate_stats_traffic_behavior(
     :rtype: dict
     """
     path = "/stats/aggregate/trafficBehavior?startTime={}&endTime={}".format(
-        start_time, end_time,
+        start_time,
+        end_time,
     )
 
     if group_pk is not None:
@@ -2366,7 +2379,7 @@ def get_aggregate_stats_traffic_behavior_ne_pk_list(
     data_format: str = None,
     top: int = None,
     last_hour: bool = None,
-    is_aggregated: bool = None
+    is_aggregated: bool = None,
 ) -> dict:
     """Get aggregate Traffic Behavioral stats data filter by query
     parameters
@@ -2413,7 +2426,8 @@ def get_aggregate_stats_traffic_behavior_ne_pk_list(
     :rtype: dict
     """
     path = "/stats/aggregate/trafficBehavior?startTime={}&endTime={}".format(
-        start_time, end_time,
+        start_time,
+        end_time,
     )
 
     if behavioral_cat is not None:
@@ -2484,7 +2498,9 @@ def get_aggregate_stats_traffic_behavior_single_appliance(
     path = (
         "/stats/aggregate/trafficBehavior/"
         + "{}?startTime={}&endTime={}".format(
-            ne_pk, start_time, end_time,
+            ne_pk,
+            start_time,
+            end_time,
         )
     )
 
@@ -3584,9 +3600,7 @@ def get_aggregate_stats_security_policy_single_appliance(
         + "{}?startTime={}&endTime={}&granularity={}&".format(
             ne_pk, start_time, end_time, granularity
         )
-        + "fromZone={}&toZone={}".format(
-            from_zone, to_zone
-        )
+        + "fromZone={}&toZone={}".format(from_zone, to_zone)
     )
 
     if top is not None:
@@ -3732,11 +3746,8 @@ def get_aggregate_stats_top_talkers_ne_pk_tunnels(
         parameters
     :rtype: dict
     """
-    path = (
-        "/stats2/aggregate/topTalkers?"
-        + "startTime={}&endTime={}".format(
-            start_time, end_time
-        )
+    path = "/stats2/aggregate/topTalkers?" + "startTime={}&endTime={}".format(
+        start_time, end_time
     )
 
     if top is not None:
@@ -3900,7 +3911,8 @@ def get_aggregate_stats_ports_ne_pk_tunnels(
     :rtype: dict
     """
     path = "/stats/aggregate/ports?startTime={}&endTime={}".format(
-        start_time, end_time,
+        start_time,
+        end_time,
     )
 
     if is_source is not None:

--- a/pyedgeconnect/orch/_alarm.py
+++ b/pyedgeconnect/orch/_alarm.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # alarm : Alarms
+from __future__ import annotations
 
 
 def get_alarms_from_appliances(

--- a/pyedgeconnect/orch/_appliance.py
+++ b/pyedgeconnect/orch/_appliance.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # appliance : Add, delete and modify appliances
+from __future__ import annotations
 
 
 def get_appliances(self) -> list:

--- a/pyedgeconnect/orch/_appliance_backup.py
+++ b/pyedgeconnect/orch/_appliance_backup.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # applianceBackup : ECOS backup and restore
+from __future__ import annotations
 
 
 def backup_appliance_config(

--- a/pyedgeconnect/orch/_appliance_resync.py
+++ b/pyedgeconnect/orch/_appliance_resync.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
 #
 # applianceResync : Orchestrator appliance configuration synchronization
+from __future__ import annotations
 
 
 def appliance_resync(

--- a/pyedgeconnect/orch/_bonded_tunnels_configuration.py
+++ b/pyedgeconnect/orch/_bonded_tunnels_configuration.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # bondedTunnelsConfiguration : ECOS bonded tunnel configuration
+from __future__ import annotations
 
 
 def get_bonded_tunnel_details(

--- a/pyedgeconnect/orch/_debug_files.py
+++ b/pyedgeconnect/orch/_debug_files.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # debugFiles : ECOS debug files like tcpdump, snapshots, sysdumps
+from __future__ import annotations
 
 
 def get_debug_files_from_appliance(

--- a/pyedgeconnect/orch/_discovery.py
+++ b/pyedgeconnect/orch/_discovery.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # discovery : Get and modify the discovery configuration
+from __future__ import annotations
 
 
 def get_appliance_discovery_emails(

--- a/pyedgeconnect/orch/_exception.py
+++ b/pyedgeconnect/orch/_exception.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # exception : Exception configuration
+from __future__ import annotations
 
 
 def get_tunnel_exceptions(

--- a/pyedgeconnect/orch/_ip_objects.py
+++ b/pyedgeconnect/orch/_ip_objects.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
 #
 # ipObjects : IP address groups and service groups management
+from __future__ import annotations
 
 
 def get_all_address_groups(self) -> list:

--- a/pyedgeconnect/orch/_network_memory.py
+++ b/pyedgeconnect/orch/_network_memory.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # networkMemory : ECOS erase network memory
+from __future__ import annotations
 
 
 def erase_appliance_network_memory(

--- a/pyedgeconnect/orch/_pause_orchestration.py
+++ b/pyedgeconnect/orch/_pause_orchestration.py
@@ -3,6 +3,7 @@
 #
 # pauseOrchestration : Set or get appliances nePks which are paused from
 # orchestration
+from __future__ import annotations
 
 
 def get_pause_orchestration(self) -> dict:

--- a/pyedgeconnect/orch/_rbac_appliance_access_group.py
+++ b/pyedgeconnect/orch/_rbac_appliance_access_group.py
@@ -36,10 +36,13 @@ def get_all_appliance_access_groups(
 def update_appliance_access_group(
     self,
     appliance_access_group_name: str,
-    appliance_groups: list[str] = None,
-    appliance_regions: list[str] = None,
+    appliance_groups: list[str],
+    appliance_regions: list[str],
 ) -> bool:
-    """Create or update appliance access gropu / asset
+    """Create or update appliance access group / asset.
+    Both list of ``appliance_groups`` and ``appliance_regions``
+    must be specified, if no group or region is desired, provide
+    a blank list as input.
 
     .. list-table::
         :header-rows: 1
@@ -55,11 +58,11 @@ def update_appliance_access_group(
         appliance access group to create or update
     :type appliance_access_group_name: str
     :param appliance_groups: List of appliance group id's the access
-        group will allow access to, defaults to None
-    :type appliance_groups: list[str], optional
+        group will allow access to
+    :type appliance_groups: list[str]
     :param appliance_regions: List of region id's the access group will
-        allow access to, defaults to None
-    :type appliance_regions: list[str], optional
+        allow access to
+    :type appliance_regions: list[str]
     :return: Returns True/False based on successful call
     :rtype: bool
     """

--- a/pyedgeconnect/orch/_rbac_appliance_access_group.py
+++ b/pyedgeconnect/orch/_rbac_appliance_access_group.py
@@ -3,6 +3,7 @@
 #
 # rbacApplianceAccessGroup : RBAC: Get, Add, Update, Delete appliance
 # access groups / assets
+from __future__ import annotations
 
 
 def get_all_appliance_access_groups(

--- a/pyedgeconnect/orch/_save_changes.py
+++ b/pyedgeconnect/orch/_save_changes.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # saveChanges : ECOS save configuration changes
+from __future__ import annotations
 
 
 def save_changes_ne_pk_list(

--- a/pyedgeconnect/orch/_tcpdump.py
+++ b/pyedgeconnect/orch/_tcpdump.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # tcpdump : ECOS Packet capture
+from __future__ import annotations
 
 
 def tcpdump_run(

--- a/pyedgeconnect/orch/_template.py
+++ b/pyedgeconnect/orch/_template.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # template : ECOS configuration templates
+from __future__ import annotations
 
 
 def get_all_template_groups(self) -> dict:

--- a/pyedgeconnect/orch/_third_party_tunnels_configuration.py
+++ b/pyedgeconnect/orch/_third_party_tunnels_configuration.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # thirdPartyTunnelsConfiguration : ECOS third party tunnel configuration
+from __future__ import annotations
 
 
 def get_passthrough_tunnel_details(

--- a/pyedgeconnect/orch/_timeseries_stats.py
+++ b/pyedgeconnect/orch/_timeseries_stats.py
@@ -137,7 +137,7 @@ def get_timeseries_stats_tunnel_single_appliance(
     """
     path = (
         "/stats/timeseries/tunnel/"
-        + "{}?startTime={}&endTime={}&granularity={}&tunnel_name={}".format(
+        + "{}?startTime={}&endTime={}&granularity={}&tunnelName={}".format(
             ne_pk, start_time, end_time, granularity, tunnel_name
         )
     )
@@ -2347,9 +2347,7 @@ def get_timeseries_stats_security_policy_single_appliance(
     """
     path = (
         "/stats/timeseries/securityPolicy/"
-        + "{}?startTime={}&endTime={}".format(
-            ne_pk, start_time, end_time
-        )
+        + "{}?startTime={}&endTime={}".format(ne_pk, start_time, end_time)
         + "&granularity={}&fromZone={}&toZone={}".format(
             granularity, from_zone, to_zone
         )

--- a/pyedgeconnect/orch/_timeseries_stats.py
+++ b/pyedgeconnect/orch/_timeseries_stats.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # timeseriesStats : ECOS time series statistics
+from __future__ import annotations
 
 
 def get_timeseries_stats_appliance_process_state(

--- a/pyedgeconnect/orch/_tunnels_configuration.py
+++ b/pyedgeconnect/orch/_tunnels_configuration.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # tunnelsConfiguration : ECOS tunnel configuration
+from __future__ import annotations
 
 
 def get_total_tunnel_count(

--- a/pyedgeconnect/orch/_upgrade_appliances.py
+++ b/pyedgeconnect/orch/_upgrade_appliances.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
 #
 # upgradeAppliances : Validate and upgrade appliances
+from __future__ import annotations
 
 
 def validate_appliance_upgrade(

--- a/pyedgeconnect/orch/_user.py
+++ b/pyedgeconnect/orch/_user.py
@@ -42,7 +42,7 @@ def get_all_users(
             * keyword **salt** (`str`): Usually left blank
     :rtype: list
     """
-    return self._post("/users")
+    return self._get("/users")
 
 
 def get_user(

--- a/pyedgeconnect/orch/_vrf.py
+++ b/pyedgeconnect/orch/_vrf.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # vrf : Routing Segments
+from __future__ import annotations
 
 
 def get_routing_segmentation_enable_status(

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ setup(
         "Topic :: System :: Networking",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3 :: Only",
         "Operating System :: OS Independent",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     keywords="silver peak, silverpeak, silver peak python, aruba edge connect, edge connect",
     packages=find_packages(),
     package_dir={"pyedgeconnect": "pyedgeconnect"},
-    python_requires=">=3.9, <4",
+    python_requires=">=3.7, <4",
     zip_safe=False,
     install_requires=["requests"],
     extras_require={


### PR DESCRIPTION
0.15.1-a1 -- 2022-06-23
-----------------------


🚀 Features
~~~~~~~~~~~~~

**Backwards compatability**: Introduced support back to Python 3.7


Added the following EdgeConnect functions from Swagger:

from .ecos._disk_usage
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_disk_usage`

from .ecos._dns
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_dns_config`
  - :func:`~pyedgeconnect.EdgeConnect.set_appliance_dns_config`

from .ecos._memory
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_memory`

from .ecos._statistics
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_stats_minute_range`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_stats_minute_file`

from .ecos._time
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_time`
~~~~~~~~~~~~~

🐛 Bug Fixes
~~~~~~~~~~~~~~

- `#4 <https://github.com/SPOpenSource/edgeconnect-python/issues/4>`_ -
  :func:`~pyedgeconnect.Orchestrator.get_all_users` was using POST
  instead of GET
- `#6 <https://github.com/SPOpenSource/edgeconnect-python/issues/6>`_ -
  :func:`~pyedgeconnect.Orchestrator.update_appliance_access_group`
  remove default values for appliance_groups and appliance_regions
- `#7 <https://github.com/SPOpenSource/edgeconnect-python/issues/7>`_ -
  :func:`~pyedgeconnect.Orchestrator.get_timeseries_stats_tunnel_single_appliance`
  update tunnel_name query in URL to tunnelName

~~~~~~~~~~~~~~


🐛 Known Issues
~~~~~~~~~~~~~~~

.. warning::

  The following two functions for the _ip_objects submodule exprience
  errors at this time. These function do work in the Orchestrator UI:

  - :func:`~pyedgeconnect.Orchestrator.bulk_upload_address_group`
  - :func:`~pyedgeconnect.Orchestrator.bulk_upload_service_group`