### PR TITLE
Release/0.15.2 a1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,10 @@ wheels/
 .installed.cfg
 *.egg
 
-# Dev Tests
+# Dev
+.vscode
+
+# Tests
 tests/dev
 .tox
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,11 @@ wheels/
 .installed.cfg
 *.egg
 
-# Tests & Documentation
-tests/
+# Dev Tests
+tests/dev
+.tox
+
+# Documentation
 docs/build/
 docs/source/_build
 examples/generate_preconfig/preconfig_outputs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 exclude *.nix
 exclude .pre-commit-config.yaml
 include *.py
-include testing/*.py
+include tests/test*.py
 include tox.ini
 include *.md
 include LICENSE

--- a/_version.py
+++ b/_version.py
@@ -1,1 +1,1 @@
-version = "0.15.1a1.dev0"
+version = "0.15.1a2.dev28"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,7 +16,7 @@ author = "Zach Camara"
 # Main version number
 version = "0.15"
 # The full version, including alpha/beta/rc tags
-release = "0.15.1-a1"
+release = "0.15.2-a1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/examples/generate_preconfig.rst
+++ b/docs/source/examples/generate_preconfig.rst
@@ -3,11 +3,18 @@
 
 .. important::
 
-    The following example is more complex code than the other examples,
+    The following example is more complex code than the general examples,
     generating data and interacting with Orchestrator. Using and
     modifying these examples requires a greater understanding of python
     functions, handling variables, and additional tools such as Jinja.
 
+
+.. note::
+
+    The code referenced in this document and all published examples
+    with pyedgeconnect are available from the GitHub repository within the
+    `examples <https://https://github.com/SPOpenSource/edgeconnect-python/tree/main/examples>`_
+    folder
 
 Generate EdgeConnect Preconfig
 ------------------------------
@@ -154,17 +161,19 @@ Additional availble runtime arguments are as follows:
 - ``-o`` or ``--orch``
     - Type: String
     - Desc: Specify the Orchestrator IP or FQDN
-    - Example values: ``10.100.1.90`` or ``orchestrator.<company>.com``
+    - Example values: ``192.0.2.100`` or ``orchestrator.<company>.com``
     - Default value: ``None``
 - ``-u`` or ``--upload``
     - Type: Boolean
-    - Desc: Upload the rendered YAML preconfig to Orchestrator
-    - Accepted values: ``True`` or ``False``
+    - Desc: Upload the rendered YAML preconfig to Orchestrator.
+      Including the ``-u`` will translate to ``True``, no option will
+      default to ``False``
     - Default value: ``False``
 - ``-aa`` or ``--autoapply``
     - Type: Boolean
-    - Desc: Auto-apply the YAML preconfig on Orchestrator to a discovered appliance
-    - Accepted values: ``True`` or ``False``
+    - Desc: Auto-apply the YAML preconfig on Orchestrator to a
+      discovered appliance. Including the ``-aa`` will translate to
+      ``True``, no option will default to ``False``
     - Default value: ``False``
 - ``-j`` or ``--jinja``
     - Type: String
@@ -209,7 +218,8 @@ Orchestrator API calls
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The two API calls to Orchestrator (outside of authentication) are
-``validate_preconfig`` and ``create_preconfig``.
+:func:`pyedgeconnect.Orchestrator.validate_preconfig` and
+:func:`pyedgeconnect.Orchestrator.create_preconfig`.
 
 The ``validate_preconfig`` function sends the preconfig YAML text to
 Orchestrator and will either return a success (HTTP 200 OK) or if

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -3,8 +3,10 @@ Example Code from Repository
 ============================
 
 All examples documented in this section are available from the
-GitHub repository within the ``examples`` folder:
-https://github.com/SPOpenSource/edgeconnect-python/tree/main/examples
+GitHub repository within the
+`examples <https://https://github.com/SPOpenSource/edgeconnect-python/tree/main/examples>`_
+folder:
+
 
 Example script documentation and instructions
 
@@ -14,3 +16,4 @@ Example script documentation and instructions
    auth_example
    basic_examples
    generate_preconfig
+   upload_security_policy

--- a/docs/source/examples/upload_security_policy.rst
+++ b/docs/source/examples/upload_security_policy.rst
@@ -1,0 +1,296 @@
+.. upload_security_policy:
+
+
+.. important::
+
+    The following example is more complex code than the general examples,
+    generating data and interacting with Orchestrator. Using and
+    modifying these examples requires a greater understanding of python
+    functions, handling variables, and conforming source data to your
+    own environment.
+
+    Updating the security policy of an EdgeConnect, especially with
+    automation, should be treated with caution as a bad firewall policy
+    could allow unwanted traffic or block unintended production traffic.
+    This code example is not meant to check the intent of any rules,
+    simply show how policy can be uploaded in an automated fashion.
+
+.. note::
+
+    The code referenced in this document and all published examples
+    with pyedgeconnect are available from the GitHub repository within the
+    `examples <https://https://github.com/SPOpenSource/edgeconnect-python/tree/main/examples>`_
+    folder:
+
+Upload EdgeConnect Security Policy
+----------------------------------
+
+This example uses a CSV file as source data to generate a security
+policy for EdgeConnect. The security policy can be uploaded to a net-new
+Template Group to later be applied to multiple appliances or pushed
+directly to a single appliance.
+
+The client running the script communicates with Orchestrator, and
+Orchestrator in turn passes the data to the Edge Connect appliance if
+pushing policy directly to an appliance.
+
+EdgeConnect Firewall Zone Behavior
+==================================
+
+Prior to Orchestrator 9+, Zone firewall rules are required for the
+source Zone to the assigned Zone of the overlay the traffic will match
+into as well as rules for egressing the overlay Zone to the final
+destination Zone.
+
+For example:
+
+Traffic is sourced from a LAN-side Zone of "Users", crossing into
+the Overlays, all of which have a zone of "Fabric", and finally when
+reaching the far-end, egressing to a zone of "Protected."
+
+For a rule to allow ``192.0.2.0/24`` from ``Users`` to ``198.51.100.0/24`` in
+``Protected`` there would be two rules required:
+
+    .. list-table::
+        :header-rows: 1
+
+        * - From Zone
+          - To Zone
+          - Source IP
+          - Dest IP
+        * - Users
+          - Fabric
+          - 192.0.2.0/24
+          - 198.51.100.0/24
+        * - Fabric
+          - Protected
+          - 192.0.2.0/24
+          - 198.51.100.0/24
+
+For Orchestrator 9+, on the Firewall Zone Secuirty Policies page
+(``Configuration -> Overlays & Security -> Security -> Firewall Zone Security Policies``)
+there is a toggle for ``New Firewall Zoning``. When enabled, this allows
+rules to account for end-to-end behavior and no longer requires zones
+for the overlays. For the same use case there would be a single rule:
+
+    .. list-table::
+        :header-rows: 1
+
+        * - From Zone
+          - To Zone
+          - Source IP
+          - Dest IP
+        * - Users
+          - Protected
+          - 192.0.2.0/24
+          - 198.51.100.0/24
+
+
+Python Script & Orchestrator API calls
+======================================
+
+The script will first check in with Orchestrator to pull information
+to correlate object id's to the friendly names used in the source data
+such as appliance hostname, zone names, and overlay names.
+
+.. note::
+
+    Zones referenced in the policy must already exist in Orchestrator.
+    While there are pyedgeconnect functions to create Zones, this
+    example does not create previously undefined Zones from the ruleset
+    in Orchestrator.
+
+    The example data included in the file ``security_policy.csv`` must
+    be updated accordingly for your environment referencing appropriate
+    security zones, rule priorites, merge settings and/or default
+    logging levels where applicable.
+
+    IP Ranges used in sample rules follow RFC 5735 as example ranges
+
+For each rule specified, add match criteria to the ruleset with the
+specified priority and within the appropriate zone pair.
+
+Once the ruleset is complete, the security map will be installed to the
+specified new Template Group or appliance directly per the runtime
+arguments.
+
+.. note::
+
+    To reference all possible match criteria fields, get existing
+    security policy from an EdgeConnect to see the corresponding JSON.
+    This can be proxied through Orchestrator with
+    :func:`pyedgeconnect.Orchestrator.appliance_get_api` while
+    specifying the nePk of the appliance to the endpoint
+    ``/securityMaps``, or connecting directly to the appliance with
+    :func:`pyedgeconnect.EdgeConnect.get_appliance_security_policy_map`
+
+
+Runtime arguments
+^^^^^^^^^^^^^^^^^
+
+The python script has multiple runtime arguments defined. The primary
+required argument is ``-c`` or ``--csv`` to specify the CSV file to be
+read as source data for generating the security policy.
+
+The destination of the rules will depend on one of the two following
+options:
+
+* Use ``-a`` or ``--appliance`` to specify the appliance hostname to
+  apply the policy to directly
+* Use ``-tg`` or ``--templategroup`` to specify the name of a new
+  Template Group to be created with the security policy selected
+
+Running the script and pushing rules to an appliance named MY-APPLIANCE-01:
+
+.. code-block:: bash
+
+    python upload_security_policy.py -c security_policy.csv -a MY-APPLIANCE-01
+
+Additional availble runtime arguments are as follows:
+
+- ``-dll`` or ``--denyloglevel``
+    - Type: Integer
+    - Desc: Specify the Log Level for deny all log events
+    - Example values: ``0`` for none or ``8`` for debug
+    - Default value: ``2``
+- ``-m`` or ``--merge``
+    - Type: Boolean
+    - Desc: Merge rules with existing rules on appliance, will overwrite
+      rules with same priority value in a zone pair. Including the
+      ``-m`` will translate to ``True``, no option will default to
+      ``False``
+    - Default value: ``False``
+- ``-o`` or ``--orch``
+    - Type: String
+    - Desc: Specify the Orchestrator IP or FQDN
+    - Example values: ``192.0.2.100`` or ``orchestrator.<company>.com``
+    - Default value: ``None``
+
+Running the script and pushing rules to a Template Group named
+Group-Sec-Policy set to merge and default log level of 3:
+
+.. code-block:: bash
+
+    python upload_security_policy.py -c security_policy.csv -tg Group-Sec-Policy -m -dll 3
+
+
+CSV File / Source Data for Variables
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In this example the source data for generating a security ruleset is a
+CSV file. The variables referenced in the match criteria of the python
+correspond to the headers in the CSV file.
+
+.. important::
+
+    The included CSV file has headers for all possible match criteria
+    as of Orchestrator 9.1. As new match criteria is introduced it may
+    be necessary to add columns in the CSV and if-statements in the
+    python to add appropriate criteria for new options. Similarly,
+    columsn for paramters that are unused in the rules are not necessary
+    to be present in the CSV file.
+
+    In the opposite direction, features such as Address or Service
+    groups were only introduced in Orchestrator 9.1, and would not apply
+    to policy for a pre-9.1 environment.
+
+.. note::
+
+    * EdgeConnect 8.x only supports ~600 rules
+    * This script only supports a maximum of 1000 rules
+    * Rule priorities for appliance ruleset should be in the range of 25000+
+    * Rule priorities for template group policies should be between 1000-9999
+
+Below is a reference for the values currently supported for the CSV file.
+
+The columns ``rule_priority``, ``action``, ``src_zone``, and
+``dst_zone`` are required, other headers are optional.
+
+* ``rule_priority``: The priority of the rule in the zone pair
+* ``action``: Allow or deny matching traffic, e.g. ``allow`` or ``deny``
+* ``src_zone``: Source Firewall Zone, e.g. ``Corp``
+* ``dst_zone``: Destination Firewall Zone, e.g. ``Public``
+* ``acl``: Name of ACL to match
+* ``src_ip``: Source IP Address to match, e.g. ``192.0.2.0/24``
+* ``dst_ip``: Destination IP Address to match, e.g. ``8.8.8.8/32``
+* ``either_ip``: Source or Destination IP Address to match
+* ``src_addrgrp_groups``: Source Address Group
+* ``dst_addrgrp_groups``: Destination Address Group
+* ``either_addrgrp_groups``: Source or Destination Address Group
+* ``protocol``: Protocol to match, e.g. ``ip``, ``icmp``
+* ``src_port``: Source IP Port to match, e.g. ``162``
+* ``dst_port``: Destination IP Port to match, e.g. ``443``
+* ``vlan``: Interface to match on, e.g. ``lan0``, ``lan0.10``
+* ``application``: Application name to match (built-in or user-defined)
+* ``app_group``: Application group name to match (built-in or user-defined)
+* ``dscp``: DSCP marking to match, e.g. ``af11``
+* ``src_dns``: Source DNS to match
+* ``dst_dns``: Destination DNS to match, e.g. ``*google.com``
+* ``either_dns``: Source or Destination DNS to match
+* ``src_geo``: Source geo to match, e.g. ``Brazil``
+* ``dst_geo``: Destination geo to match, e.g. ``United States``
+* ``either_geo``: Source or Destination geo to match
+* ``src_service``: Source Address Map name to match
+* ``dst_service``: Destination Address Map name to match
+* ``either_service``: Source or Destination Address Map name to match
+* ``tbehavior``: Identified traffic behavior, e.g. ``Idle``, ``Voice``,
+  ``Video_Conferencing``
+* ``overlay``: Overlay name to match
+* ``internet``: ``Fabric`` or ``Internet``
+* ``logging``: Enable logging for rule with ``enable``, defaults to
+  ``disable``
+* ``logging_priority``: Loggig priority level for rule. Defaults to ``0``
+
+Logging levels translate as follows:
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Numeric Level
+          - Log Level
+        * - 0
+          - None
+        * - 1
+          - Emergency
+        * - 2
+          - Alert
+        * - 3
+          - Critical
+        * - 4
+          - Error
+        * - 5
+          - Warning
+        * - 6
+          - Notice
+        * - 7
+          - Info
+        * - 8
+          - Debug
+
+Orchestrator API calls
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The API calls to Orchestrator (outside of authentication) used in this
+example are:
+
+* :func:`pyedgeconnect.Orchestrator.get_appliances`
+   * Retrieves all appliances to correlate provided appliance name to
+     appliance id for pushing security rules to appliance
+* :func:`pyedgeconnect.Orchestrator.get_all_overlays_config`
+   * Retrieves all overlays to correlate overlay names in policy source
+     data to overlay ids
+* :func:`pyedgeconnect.Orchestrator.get_all_template_groups`
+   * Retrieves all template groups to make sure new template group name
+     is unique, will otherwise exit
+* :func:`pyedgeconnect.Orchestrator.get_zones`
+   * Retrieves all zones to correlate zone names in policy source data
+     to zone ids
+* :func:`pyedgeconnect.Orchestrator.create_template_group`
+   * Creates new template group in Orchestrator
+* :func:`pyedgeconnect.Orchestrator.select_templates_for_template_group`
+   * Selects active templates in template group, in this case, security
+     policy
+* :func:`pyedgeconnect.Orchestrator.appliance_post_api`
+   * Sends a POST to appliance ECOS API endpoint, in this case to
+     ``/securityMaps`` to push security policy directly to appliance
+     through an Orchestrator API endpoint as passthrough.

--- a/docs/source/pyedgeconnect.rst
+++ b/docs/source/pyedgeconnect.rst
@@ -2,12 +2,16 @@
 Module Documentation
 ===============================
 
-Module contents
----------------
-
-.. automodule:: pyedgeconnect
+Orchestrator
+----------------
+.. autoclass:: pyedgeconnect.Orchestrator
    :members:
-   :special-members: __init__
-   :undoc-members:
+   :show-inheritance:
+   :member-order: bysource
+
+EdgeConnect
+----------------
+.. autoclass:: pyedgeconnect.EdgeConnect
+   :members:
    :show-inheritance:
    :member-order: bysource

--- a/docs/source/release-notes/0.15.2-a1.rst
+++ b/docs/source/release-notes/0.15.2-a1.rst
@@ -1,0 +1,151 @@
+0.15.2-a1 -- 2022-07-29
+-----------------------
+
+
+🚀 Features
+~~~~~~~~~~~~~
+
+- New code example: **upload security policy** - Upload Firewall
+  Security Policies to an appliance or create a new Template Group to
+  be assigned to appliances
+
+  - Overview: :doc:`/examples/upload_security_policy`
+  - Code: `upload_security_policy <https://github.com/SPOpenSource/edgeconnect-python/tree/main/examples/upload_security_policy>`_
+
+- Updated logging messages (when using ``log_console`` and ``log_file``
+  parameters for EdgeConnect and Orchestrator) to include base Orch FQDN
+  or ECOS FQDN to be clear when logging statements across different
+  instances in a single script.
+
+
+Added the following EdgeConnect functions from Swagger:
+
+from .ecos._alarm
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_alarms`
+  - :func:`~pyedgeconnect.EdgeConnect.acknowledge_appliance_alarms`
+  - :func:`~pyedgeconnect.EdgeConnect.clear_appliance_alarms`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_alarm_descriptions`
+  - :func:`~pyedgeconnect.EdgeConnect.add_note_appliance_alarms`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_alarms`
+
+from .ecos._bonded_tunnel
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnels_state`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_bonded_tunnels_state`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_all_bonded_tunnel_ids`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnel_aliases`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnels_config`
+  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_all_bonded_tunnels`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_single_bonded_tunnel_config`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_single_bonded_tunnel`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_bonded_tunnels_config`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_multiple_bonded_tunnels`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnel_live_view_info`
+
+from .ecos._cli
+  - :func:`~pyedgeconnect.EdgeConnect.perform_appliance_cli_command`
+  - :func:`~pyedgeconnect.EdgeConnect.perform_appliance_multiple_cli_command`
+
+from .ecos._deployment
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_deployment`
+
+from .ecos._local_subnets
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_subnets`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_subnets_all_vrfs`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_subnets_single_vrf`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_locally_configured_subnets`
+  - :func:`~pyedgeconnect.EdgeConnect.update_appliance_all_locally_configured_subnets`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_locally_configured_subnets_single_vrf`
+  - :func:`~pyedgeconnect.EdgeConnect.update_appliance_all_locally_configured_subnets_single_vrf`
+  - :func:`~pyedgeconnect.EdgeConnect.add_appliance_locally_configured_routes`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_locally_configured_routes`
+  - :func:`~pyedgeconnect.EdgeConnect.appliance_find_preferred_route`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_routing_peers_info`
+
+from .ecos._peers
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_peers`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_peers_ec_only`
+
+from .ecos._security_maps
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policies`
+  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_security_policies`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policy_map`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policy_zone_pair`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_security_policy_zone_pair`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_security_policy_rule`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policy_settings`
+  - :func:`~pyedgeconnect.EdgeConnect.set_appliance_security_policy_settings`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policy_settings_by_map_name`
+
+from .ecos._third_party_tunnel
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_3rdparty_tunnels_state`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_3rdparty_tunnels_state`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_all_3rdparty_tunnel_ids`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_3rdparty_tunnel_aliases`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_3rdparty_tunnels_config`
+  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_multiple_3rdparty_tunnels`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_single_3rdparty_tunnel_config`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_single_3rdparty_tunnel`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_3rdparty_tunnels_config`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_multiple_3rdparty_tunnels`
+
+from .ecos._tunnel
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnels_config_and_state`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnels_config`
+  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_all_tunnels`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_single_tunnel_config`
+  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_single_tunnel`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_single_tunnel`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_all_tunnel_ids`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnel_aliases`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_tunnels_config`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_tunnels_state`
+  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_multiple_tunnels`
+  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_multiple_tunnels`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnel_source_endpoints`
+  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_passthrough_tunnel_source_endpoints`
+  - :func:`~pyedgeconnect.EdgeConnect.start_appliance_tunnel_mtu_discovery`
+  - :func:`~pyedgeconnect.EdgeConnect.apply_appliance_tunnel_template`
+  - :func:`~pyedgeconnect.EdgeConnect.set_appliance_tunnels_ipsec_psk`
+
+
+🐛 Bug Fixes
+~~~~~~~~~~~~~~
+
+- `#10 <https://github.com/SPOpenSource/edgeconnect-python/issues/10>`_ -
+  :func:`~pyedgeconnect.Orchestrator.login` and
+  :func:`~pyedgeconnect.EdgeConnect.login` returned ``True`` even when
+  login failed
+- `#11 <https://github.com/SPOpenSource/edgeconnect-python/issues/11>`_ -
+  :func:`~pyedgeconnect.Orchestrator.appliance_resync` had incorrect
+  endpoint of ``/applianceResyncSynchronize``, corrected to
+  ``/applianceResync``
+- `#12 <https://github.com/SPOpenSource/edgeconnect-python/issues/12>`_ -
+  The preconfig generator example code had the option to look for a
+  column for appliance serial number to match preconfig to, however,
+  didn't include that information when creating the preconfig on
+  Orchestrator as the parameter wasn't specified.
+- `#13 <https://github.com/SPOpenSource/edgeconnect-python/issues/13>`_ -
+  Corrected return type-hint for methods that use `return_type="full_response"`
+  with hint of requests.Response object rather than `dict`
+
+
+🧰 Maintenance / Other
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Introduced initial automated tox testing for Python 3.7, 3.8, 3.9, 3.10
+- run pytest tests
+
+additional `testenv:format` environment
+- Check isort for imported packages
+- Check flake8
+
+
+🐛 Known Issues
+~~~~~~~~~~~~~~~
+
+.. warning::
+
+  The following two functions for the _ip_objects submodule exprience
+  errors at this time. These function do work in the Orchestrator UI:
+  :func:`~pyedgeconnect.Orchestrator.bulk_upload_address_group` and
+  :func:`~pyedgeconnect.Orchestrator.bulk_upload_service_group`

--- a/docs/source/release-notes/index.rst
+++ b/docs/source/release-notes/index.rst
@@ -8,6 +8,7 @@ All of the release notes for pyedgeconnect are organized below
 ==================
 
 .. toctree::
+    0.15.2-a1
     0.15.1-a1
     0.15.0-a1
     0.14.0-a2

--- a/examples/generate_preconfig/preconfig.py
+++ b/examples/generate_preconfig/preconfig.py
@@ -196,6 +196,7 @@ with open(csv_filename, encoding="utf-8-sig") as csvfile:
                     yaml_preconfig=yaml_preconfig,
                     auto_apply=auto_apply,
                     tag=row["hostname"],
+                    serial_number=appliance_serial,
                     comment=f"Created/Uploaded @ {comment_timestamp}",
                 )
                 print(f'Posted EC Preconfig {row["hostname"]}')

--- a/examples/upload_security_policy/security_policy.csv
+++ b/examples/upload_security_policy/security_policy.csv
@@ -1,0 +1,9 @@
+rule_priority,action,src_zone,dst_zone,acl,src_ip,dst_ip,either_ip,protocol,src_port,dst_port,either_port,vlan,application,logging,logging_priority,comment
+25000,allow,corp,corp,,192.0.2.0/29,192.0.2.10/32,,rdp,,,,lan0.100,,enable,1,vlan 100 rdp to host1
+25010,allow,corp,corp,,192.0.2.0/29,192.0.2.11/32,,rdp,,,,lan0.100,,enable,2,vlan 100 rdp to host2
+25020,allow,corp,corp,,192.0.2.0/29,192.0.2.12/32,,rdp,,,,lan0.100,,enable,3,vlan 100 rdp to host3
+25030,deny,corp,corp,,192.0.2.0/29,192.0.2.13/32,,,,443,,,,,,Deny HTTPS to .13
+25040,deny,corp,corp,,192.0.2.0/29,192.0.2.14/32,,,,443,,,,,,Deny HTTPS to .14
+25000,allow,corp,Public,,,,192.0.2.0/24,,,,,,Office365Common,,,Allow to O365
+25010,deny,corp,Public,,,,192.0.2.0/24,,,443,,,Salesforce,,,Allow HTTPS to Salesforce
+25020,allow,corp,Public,,,,192.0.2.0/24,,,,,,Zoom,,,Allow Zoom

--- a/examples/upload_security_policy/upload_security_policy.py
+++ b/examples/upload_security_policy/upload_security_policy.py
@@ -1,0 +1,539 @@
+import argparse
+import csv
+import getpass
+import os
+
+from pyedgeconnect import Orchestrator
+
+# Parse arguments
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-c",
+    "--csv",
+    help="specify source csv file for security rules",
+    type=str,
+    required=True,
+)
+parser.add_argument(
+    "-a",
+    "--appliance",
+    help="specify appliance name to apply rules to",
+    type=str,
+)
+parser.add_argument(
+    "-tg",
+    "--templategroup",
+    help="specify template group name to apply rules to",
+    type=str,
+)
+parser.add_argument(
+    "-dll",
+    "--denyloglevel",
+    help="log level in template for deny all log events",
+    type=int,
+)
+parser.add_argument(
+    "-m",
+    "--merge",
+    help="merge new rules with any existing rules",
+    action=argparse.BooleanOptionalAction,
+)
+parser.add_argument(
+    "-o",
+    "--orch",
+    help="specify Orchestrator URL",
+    type=str,
+)
+args = parser.parse_args()
+
+# CSV file for generating security rules
+csv_filename = vars(args)["csv"]
+
+# Appliance name to apply security rules to
+appliance_name = vars(args)["appliance"]
+
+# TemplateGroup to create and apply security rules to
+template_group_name = vars(args)["templategroup"]
+
+if vars(args)["denyloglevel"] is not None:
+    deny_all_log_level = vars(args)["denyloglevel"]
+else:
+    deny_all_log_level = 2
+
+# Check if appliance or templategroup has been specified and exit on
+# conflicting conditions, can only use one
+if appliance_name is None and template_group_name is None:
+    print("Must specify appliance or template group to create rules!")
+    exit()
+elif appliance_name is not None and template_group_name is not None:
+    print("Cannot specify appliance and template group at same time!")
+    exit()
+else:
+    pass
+
+# Merge set to ``True`` will merge with existing rules on appliance.
+# Rules in same zone pair with same priority will be overwritten even
+# with Merge.
+if vars(args)["merge"] is not None:
+    merge = vars(args)["merge"]
+else:
+    merge = False
+
+# Set Orchestrator FQDN/IP via arguments, environment variable,
+# or user input
+if vars(args)["orch"] is not None:
+    orch_url = vars(args)["orch"]
+elif os.getenv("ORCH_URL") is not None:
+    orch_url = os.getenv("ORCH_URL")
+else:
+    orch_url = input("Orchstrator IP or FQDN: ")
+
+# Set Orchestrator API Key via environment variable or user input
+if os.getenv("ORCH_API_KEY") is not None:
+    orch_api_key = os.getenv("ORCH_API_KEY")
+else:
+    orch_api_key_input = input("Orchstrator API Key (enter to skip): ")
+    if len(orch_api_key_input) == 0:
+        orch_api_key = None
+        # Set user and password if present in environment variable
+        orch_user = os.getenv("ORCH_USER")
+        orch_pw = os.getenv("ORCH_PASSWORD")
+    else:
+        orch_api_key = orch_api_key_input
+
+# Instantiate Orchestrator with ``log_console`` enabled for
+# printing log messages to terminal
+orch = Orchestrator(
+    orch_url,
+    api_key=orch_api_key,
+    log_console=True,
+    verify_ssl=False,
+)
+
+# If not using API key, login to Orchestrator with username/password
+if orch_api_key is None:
+    # If username/password not in environment variables, prompt user
+    if orch_user is None:
+        orch_user = input("Enter Orchestrator username: ")
+        orch_pw = getpass.getpass("Enter Orchestrator password: ")
+    # Check if multi-factor authentication required
+    mfa_prompt = input("Are you using MFA for this user (y/n)?: ")
+    if mfa_prompt == "y":
+        orch.send_mfa(orch_user, orch_pw, temp_code=False)
+        token = input("Enter MFA token: ")
+    else:
+        token = ""
+    # Login to Orchestrator
+    confirm_auth = orch.login(orch_user, orch_pw, mfacode=token)
+    # Check that user/pass authentication works before proceeding
+    if confirm_auth:
+        pass
+    else:
+        print("Authentication to Orchestrator Failed")
+        exit()
+# If API key specified, check that key is valid before proceeding
+else:
+    confirm_auth = orch.get_orchestrator_hello()
+    if confirm_auth != "There was an internal server error.":
+        pass
+    else:
+        print("Authentication to Orchestrator Failed")
+        exit()
+
+
+if appliance_name is not None:
+    # retrieve all appliances in Orchestrator to be able correlate
+    # specified hostname to respective appliance id
+    appliances = orch.get_appliances()
+
+    ne_pk = None
+    # Find NEPK of specified appliance
+    for appliance in appliances:
+        if appliance_name == appliance["hostName"]:
+            ne_pk = appliance["nePk"]
+
+    # Check that appliance was found by hostname before continuing
+    if ne_pk is None:
+        print(
+            f"""
+            FAILED TO PROCESS:
+            Appliance: {appliance_name} was not found in Orchestrator
+            """
+        )
+
+# Get overlay id's to correlate overlay names if used in security policy
+raw_overlays = orch.get_all_overlays_config()
+overlays = {}
+
+# Map new dictionary with key/value pair of Overlay name to Overlay id
+for overlay in raw_overlays:
+    overlays[overlay["name"]] = overlay["id"]
+
+# If template group is chosen set templateApply value base values
+if template_group_name is not None:
+
+    # Retrieve existing Template Groups on Orchestrator to check for
+    # duplicate names
+    existing_template_groups = orch.get_all_template_groups()
+    # If Template Group name already exists, exit to avoid any conflict
+    # with existing Template Group
+    for group in existing_template_groups:
+        if template_group_name == group["name"]:
+            print(
+                f"WARNING: Template Group {template_group_name}"
+                "already exists in Orchestrator!"
+            )
+            if orch_api_key is None:
+                orch.logout()
+            exit()
+
+    # Instantiate TemplateGroup data object
+    template_group = {
+        "name": template_group_name,
+        "selectedTemplateNames": ["securityMaps"],
+        "templates": [{"name": "securityMaps", "valObject": {}}],
+    }
+
+    # Initial security policy to add rules to
+    security_map = {
+        "data": {},
+        "options": {
+            "merge": merge,
+            "templateApply": True,
+        },
+        "settings": {
+            "map1": {
+                # Log 'Deny All' Events at Level
+                "imp_fw_drop": deny_all_log_level
+            }
+        },
+    }
+# Initial direct to appliance security policy to add rules to
+else:
+    security_map = {
+        "data": {},
+        "options": {
+            "merge": merge,
+            "templateApply": False,
+        },
+    }
+
+# Instantiate dictionary for rules to be inserted to
+# This will later be nested into the security map object
+map_details = {}
+
+# Process rules from CSV for upload
+with open(csv_filename, encoding="utf-8-sig") as csvfile:
+    ruleset = csv.DictReader(csvfile)
+
+    # Set initial row number for row identification of data
+    # First row is headers
+    rule_number = 2
+
+    # Get configured firewall zones for ingesting rules
+    raw_zones = orch.get_zones()
+    zones = {}
+
+    # Map new dictionary with key/value pair of Zone name to Zone ID
+    for zone in raw_zones:
+        zones[raw_zones[zone]["name"]] = zone
+
+    # For each row in configuration file, add to security rules
+    for rule in ruleset:
+        try:
+            # Set rule priority
+            rule_priority = rule["rule_priority"]
+
+            # Instantiate match criteria for security rule
+            match_criteria = {}
+
+            # To identify valid values for each of the security
+            # parameters, retrieve an existing appliance security policy
+            # either through Orchestrator or directly from an appliance
+            #
+            # orch.appliance_get_api(
+            #     ne_pk=ne_pk,
+            #     url="securityMaps",
+            # )
+            # OR
+            #
+            # ec.get_appliance_security_policy_map()
+
+            # Check CSV file for all possible security parameters
+            # and add to policy object if they exist
+
+            # if acl exists and is not blank, set the value
+            if rule.get("acl") and rule.get("acl").strip():
+                match_criteria["acl"] = rule["acl"]
+            else:
+                match_criteria["acl"] = ""
+            # if src_ip exists and is not blank, set the value
+            if rule.get("src_ip") and rule.get("src_ip").strip():
+                match_criteria["src_ip"] = rule["src_ip"]
+            else:
+                pass
+            # if dst_ip exists and is not blank, set the value
+            if rule.get("dst_ip") and rule.get("dst_ip").strip():
+                match_criteria["dst_ip"] = rule["dst_ip"]
+            else:
+                pass
+            # if src_addrgrp_groups exists and is not blank, set the value
+            if (
+                rule.get("src_addrgrp_groups")
+                and rule.get("src_addrgrp_groups").strip()
+            ):
+                match_criteria["src_addrgrp_groups"] = rule[
+                    "src_addrgrp_groups"
+                ]
+            else:
+                pass
+            # if dst_addrgrp_groups exists and is not blank, set the value
+            if (
+                rule.get("dst_addrgrp_groups")
+                and rule.get("dst_addrgrp_groups").strip()
+            ):
+                match_criteria["dst_addrgrp_groups"] = rule[
+                    "dst_addrgrp_groups"
+                ]
+            else:
+                pass
+            # if either_addrgrp_groups exists and is not blank, set the value
+            if (
+                rule.get("either_addrgrp_groups")
+                and rule.get("either_addrgrp_groups").strip()
+            ):
+                match_criteria["either_addrgrp_groups"] = rule[
+                    "either_addrgrp_groups"
+                ]
+            else:
+                pass
+            # if either_ip exists and is not blank, set the value
+            if rule.get("either_ip") and rule.get("either_ip").strip():
+                match_criteria["either_ip"] = rule["either_ip"]
+            else:
+                pass
+            # if protocol exists and is not blank, set the value
+            if rule.get("protocol") and rule.get("protocol").strip():
+                match_criteria["protocol"] = rule["protocol"]
+            else:
+                pass
+            # if src_port exists and is not blank, set the value
+            if rule.get("src_port") and rule.get("src_port").strip():
+                match_criteria["src_port"] = rule["src_port"]
+            else:
+                pass
+            # if dst_port exists and is not blank, set the value
+            if rule.get("dst_port") and rule.get("dst_port").strip():
+                match_criteria["dst_port"] = rule["dst_port"]
+            else:
+                pass
+            # if vlan exists and is not blank, set the value
+            if rule.get("vlan") and rule.get("vlan").strip():
+                match_criteria["vlan"] = rule["vlan"]
+            else:
+                pass
+            # if application exists and is not blank, set the value
+            if rule.get("application") and rule.get("application").strip():
+                match_criteria["application"] = rule["application"]
+            else:
+                pass
+            # if app_group exists and is not blank, set the value
+            if rule.get("app_group") and rule.get("app_group").strip():
+                match_criteria["app_group"] = rule["app_group"]
+            else:
+                pass
+            # if dscp exists and is not blank, set the value
+            if rule.get("dscp") and rule.get("dscp").strip():
+                match_criteria["dscp"] = rule["dscp"]
+            else:
+                pass
+            # if src_dns exists and is not blank, set the value
+            if rule.get("src_dns") and rule.get("src_dns").strip():
+                match_criteria["src_dns"] = rule["src_dns"]
+            else:
+                pass
+            # if dst_dns exists and is not blank, set the value
+            if rule.get("dst_dns") and rule.get("dst_dns").strip():
+                match_criteria["dst_dns"] = rule["dst_dns"]
+            else:
+                pass
+            # if either_dns exists and is not blank, set the value
+            if rule.get("either_dns") and rule.get("either_dns").strip():
+                match_criteria["either_dns"] = rule["either_dns"]
+            else:
+                pass
+            # if src_geo exists and is not blank, set the value
+            if rule.get("src_geo") and rule.get("src_geo").strip():
+                match_criteria["src_geo"] = rule["src_geo"]
+            else:
+                pass
+            # if dst_geo exists and is not blank, set the value
+            if rule.get("dst_geo") and rule.get("dst_geo").strip():
+                match_criteria["dst_geo"] = rule["dst_geo"]
+            else:
+                pass
+            # if either_geo exists and is not blank, set the value
+            if rule.get("either_geo") and rule.get("either_geo").strip():
+                match_criteria["either_geo"] = rule["either_geo"]
+            else:
+                pass
+            # if src_service exists and is not blank, set the value
+            if rule.get("src_service") and rule.get("src_service").strip():
+                match_criteria["src_service"] = rule["src_service"]
+            else:
+                pass
+            # if dst_service exists and is not blank, set the value
+            if rule.get("dst_service") and rule.get("dst_service").strip():
+                match_criteria["dst_service"] = rule["dst_service"]
+            else:
+                pass
+            # if either_service exists and is not blank, set the value
+            if (
+                rule.get("either_service")
+                and rule.get("either_service").strip()
+            ):
+                match_criteria["either_service"] = rule["either_service"]
+            else:
+                pass
+            # if tbehavior exists and is not blank, set the value
+            # "Voice", "Video Conferencing", "Bulk Data", etc.
+            if rule.get("tbehavior") and rule.get("tbehavior").strip():
+                match_criteria["tbehavior"] = rule["tbehavior"]
+            else:
+                pass
+            # if overlay exists and is not blank, set the value
+            # Rule uses overlay id rather than name
+            if rule.get("overlay") and rule.get("overlay").strip():
+                match_criteria["overlay"] = overlays[rule["overlay"]]
+            else:
+                pass
+            # if internet exists and is not blank, set the value
+            # ``1`` for internet traffic, ``0`` for for non-internet/internal
+            if rule.get("internet") and rule.get("internet").strip():
+                match_criteria["internet"] = overlays[rule["overlay"]]
+            else:
+                pass
+
+            # Check that zones in CSV exist in Orchestrator
+            if zones.get(rule["src_zone"]) is not None:
+                pass
+            else:
+                print(
+                    f"""
+                FAILED TO PROCESS RULE ON ROW {rule_number}:
+                Zone: {rule["src_zone"]} does not exist on Orchestrator
+                Please define all zones prior to uploading rules
+
+                Rule Details:
+                {rule}
+                """
+                )
+                # Skip to next rule in ruleset
+                continue
+            if zones.get(rule["dst_zone"]) is not None:
+                pass
+            else:
+                print(
+                    f"""
+                FAILED TO PROCESS RULE ON ROW {rule_number}:
+                Zone: {rule["dst_zone"]} does not exist on Orchestrator
+                Please define all zones prior to uploading rules
+
+                Rule Details:
+                {rule}
+                """
+                )
+                # Skip to next rule in ruleset
+                continue
+
+            # Combine source and destination zones into string <srcId_dstId>
+            # E.g., 10_10 or 10_12
+            zone_pair = f'{zones[rule["src_zone"]]}_{zones[rule["dst_zone"]]}'
+
+            # If this is the first rule with this zone combination,
+            # instantiate the zone pair in the map_details and the
+            # underlying prio object for adding rules
+            if zone_pair not in map_details:
+                # Instantiate nested dictionaries for map
+                map_details[zone_pair] = {}
+                map_details[zone_pair]["prio"] = {}
+            else:
+                pass
+
+            # Set rule logging enablement
+            if rule.get("logging") == "enable":
+                logging = "enable"
+            else:
+                logging = "disable"
+
+            # Set rule logging priority
+            if (
+                rule.get("logging_priority")
+                and rule.get("logging_priority").strip()
+            ):
+                logging_priority = rule["logging_priority"]
+            else:
+                logging_priority = "0"
+
+            # Set rule comment
+            if rule.get("comment") is not None:
+                comment = rule["comment"]
+            else:
+                comment = ""
+
+            # Form rule structure with respective details
+            map_details[zone_pair]["prio"][rule_priority] = {
+                "comment": comment,
+                "gms_marked": False,
+                "match": match_criteria,
+                "misc": {
+                    "rule": "enable",
+                    "logging": logging,
+                    "logging_priority": logging_priority,
+                },
+                "set": {"action": rule["action"]},
+            }
+
+            # Increment rule number being processed
+            rule_number += 1
+
+        except Exception as e:
+            print(f"ERROR ENCOUNTERED WHEN PROCESSING RULE: {rule_number}")
+            print(e)
+
+# POST security policy as long as rules are < 1000 (1001 because rule
+# count started at 2 accounting for headers in CSV file)
+if rule_number <= 1001:
+
+    # Set rule map details into the security map
+    security_map["data"]["map1"] = map_details
+
+    # With template group option, create new template group
+    # and include security policy
+    if template_group_name is not None:
+        # Set security map into template group data
+        template_group["templates"][0]["valObject"] = security_map
+        # Create new TemplateGroup and select templates to include
+        orch.create_template_group(template_group)
+        orch.select_templates_for_template_group(
+            template_group["name"],
+            template_group["selectedTemplateNames"],
+        )
+    # With appliance option, upload rules to appliance through
+    # Orchestrator passthrough api
+    else:
+        orch.appliance_post_api(
+            ne_pk=ne_pk,
+            url="securityMaps",
+            data=security_map,
+        )
+# If ruleset longer than 1000 do not upload
+else:
+    print("WARNING - Ruleset too long to upload")
+
+
+# if not using API key, logout from Orchestrator
+if orch_api_key is None:
+    orch.logout()
+else:
+    pass

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1353,6 +1353,7 @@ class EdgeConnect(HttpCommon):
         perform_appliance_cli_command,
         perform_appliance_multiple_cli_command,
     )
+    from .ecos._deployment import get_appliance_deployment
     from .ecos._disk_usage import get_appliance_disk_usage
     from .ecos._dns import get_appliance_dns_config, set_appliance_dns_config
     from .ecos._gms import assign_orchestrator, get_orchestrator

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1359,6 +1359,19 @@ class EdgeConnect(HttpCommon):
     from .ecos._gms import assign_orchestrator, get_orchestrator
     from .ecos._interfaces import get_appliance_interfaces
     from .ecos._license import is_reboot_required
+    from .ecos._local_subnets import (
+        add_appliance_locally_configured_routes,
+        appliance_find_preferred_route,
+        delete_appliance_locally_configured_routes,
+        get_appliance_locally_configured_subnets,
+        get_appliance_locally_configured_subnets_single_vrf,
+        get_appliance_routing_peers_info,
+        get_appliance_subnets,
+        get_appliance_subnets_all_vrfs,
+        get_appliance_subnets_single_vrf,
+        update_appliance_all_locally_configured_subnets,
+        update_appliance_all_locally_configured_subnets_single_vrf,
+    )
     from .ecos._login import login, logout
     from .ecos._memory import get_appliance_memory
     from .ecos._network_interfaces import (

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1328,6 +1328,14 @@ class EdgeConnect(HttpCommon):
             self.logger.addHandler(self.console_handler)
 
     # Imported methods
+    from .ecos._alarm import (
+        acknowledge_appliance_alarms,
+        add_note_appliance_alarms,
+        clear_appliance_alarms,
+        delete_appliance_alarms,
+        get_appliance_alarm_descriptions,
+        get_appliance_alarms,
+    )
     from .ecos._bonded_tunnel import (
         configure_appliance_all_bonded_tunnels,
         delete_appliance_multiple_bonded_tunnels,
@@ -1340,6 +1348,10 @@ class EdgeConnect(HttpCommon):
         get_appliance_multiple_bonded_tunnels_config,
         get_appliance_multiple_bonded_tunnels_state,
         get_appliance_single_bonded_tunnel_config,
+    )
+    from .ecos._cli import (
+        perform_appliance_cli_command,
+        perform_appliance_multiple_cli_command,
     )
     from .ecos._disk_usage import get_appliance_disk_usage
     from .ecos._dns import get_appliance_dns_config, set_appliance_dns_config

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -126,21 +126,22 @@ class HttpCommon:
         :return: Requests Response object
         :rtype: requests.Response
         """
+        response_method = (
+            str(response.request)
+            .replace("<PreparedRequest ", "")
+            .replace(">", "")
+        )
         if response.status_code not in expected_status:
             self.logger.error(
-                "{} {} | Received HTTP {} | Response text: {}".format(
-                    response.request,
-                    api_path,
-                    response.status_code,
-                    response.text,
-                )
+                f"{response_method} {api_path} | Received HTTP "
+                f"{response.status_code} | Response text: {response.text}"
             )
             # return formatted data for the source method
             # for JSON data, return a dictionary with the details of
             # the response
             if return_type == "json":
                 return {
-                    "request": response.request,
+                    "request": response_method,
                     "api_path": api_path,
                     "status_code": response.status_code,
                     "text": response.text,
@@ -157,23 +158,16 @@ class HttpCommon:
         # text from log messages for successful API calls.
         if self.log_success:
             self.logger.info(
-                "{} {} | Received HTTP {} | Response text: {}".format(
-                    response.request,
-                    api_path,
-                    response.status_code,
-                    response.text,
-                )
+                f"{response_method} {api_path} | Received HTTP "
+                f"{response.status_code} | Response text: {response.text}"
             )
         else:
             # Log successful call, omit response text in case sensitive
             # data in response text
             self.logger.info(
-                (
-                    "{} {} | Received: HTTP {} ".format(
-                        response.request, api_path, response.status_code
-                    )
-                    + "| Response text omitted to avoid logging sensitive data"
-                )
+                f"{response_method} {api_path} | Received HTTP "
+                f"{response.status_code} "
+                "| Response omitted to avoid logging sensitive data"
             )
 
         # return formatted data for the source method
@@ -463,9 +457,9 @@ class Orchestrator(HttpCommon):
             )
 
         # Setup general log settings for messages and errors
-        self.logger = logging.getLogger("orchestrator")
+        self.logger = logging.getLogger(f"orch_{url}")
         self.formatter = logging.Formatter(
-            "%(asctime)s - %(levelname)s - %(message)s"
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
         self.logger.setLevel(logging.INFO)
 
@@ -1301,9 +1295,9 @@ class EdgeConnect(HttpCommon):
             )
 
         # Setup general log settings for messages and errors
-        self.logger = logging.getLogger("edgeconnect")
+        self.logger = logging.getLogger(f"ecos_{url}")
         self.formatter = logging.Formatter(
-            "%(asctime)s - %(levelname)s - %(message)s"
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
         )
         self.logger.setLevel(logging.INFO)
 

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -366,7 +366,7 @@ class HttpCommon:
 class Orchestrator(HttpCommon):
     """Orchestrator setup and imports related methods for making API
     calls to Orchestrator. Child class of :class:`HttpCommon`
-    """
+    """  # noqa RST304
 
     def __init__(
         self,
@@ -1224,7 +1224,7 @@ class Orchestrator(HttpCommon):
 class EdgeConnect(HttpCommon):
     """Edge Connect setup and imports related methods for making API
     calls to Edge Connect appliances. Child class of :class:`HttpCommon`
-    """
+    """  # noqa RST304
 
     def __init__(
         self,

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1352,6 +1352,7 @@ class EdgeConnect(HttpCommon):
         get_appliance_network_interfaces,
         modify_network_interfaces,
     )
+    from .ecos._peers import get_appliance_peers, get_appliance_peers_ec_only
     from .ecos._reboot import request_reboot
     from .ecos._save_changes import save_changes
     from .ecos._sp_portal import register_sp_portal, register_sp_portal_status

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1328,6 +1328,19 @@ class EdgeConnect(HttpCommon):
             self.logger.addHandler(self.console_handler)
 
     # Imported methods
+    from .ecos._bonded_tunnel import (
+        configure_appliance_all_bonded_tunnels,
+        delete_appliance_multiple_bonded_tunnels,
+        delete_appliance_single_bonded_tunnel,
+        get_appliance_all_bonded_tunnel_ids,
+        get_appliance_bonded_tunnel_aliases,
+        get_appliance_bonded_tunnel_live_view_info,
+        get_appliance_bonded_tunnels_config,
+        get_appliance_bonded_tunnels_state,
+        get_appliance_multiple_bonded_tunnels_config,
+        get_appliance_multiple_bonded_tunnels_state,
+        get_appliance_single_bonded_tunnel_config,
+    )
     from .ecos._disk_usage import get_appliance_disk_usage
     from .ecos._dns import get_appliance_dns_config, set_appliance_dns_config
     from .ecos._gms import assign_orchestrator, get_orchestrator
@@ -1346,4 +1359,35 @@ class EdgeConnect(HttpCommon):
         get_appliance_stats_minute_file,
         get_appliance_stats_minute_range,
     )
+    from .ecos._third_party_tunnel import (
+        configure_appliance_multiple_3rdparty_tunnels,
+        delete_appliance_multiple_3rdparty_tunnels,
+        delete_appliance_single_3rdparty_tunnel,
+        get_appliance_3rdparty_tunnel_aliases,
+        get_appliance_3rdparty_tunnels_config,
+        get_appliance_3rdparty_tunnels_state,
+        get_appliance_all_3rdparty_tunnel_ids,
+        get_appliance_multiple_3rdparty_tunnels_config,
+        get_appliance_multiple_3rdparty_tunnels_state,
+        get_appliance_single_3rdparty_tunnel_config,
+    )
     from .ecos._time import get_appliance_time
+    from .ecos._tunnel import (
+        apply_appliance_tunnel_template,
+        configure_appliance_all_tunnels,
+        configure_appliance_multiple_tunnels,
+        configure_appliance_single_tunnel,
+        delete_appliance_multiple_tunnels,
+        delete_appliance_single_tunnel,
+        get_appliance_all_tunnel_ids,
+        get_appliance_multiple_tunnels_config,
+        get_appliance_multiple_tunnels_state,
+        get_appliance_passthrough_tunnel_source_endpoints,
+        get_appliance_single_tunnel_config,
+        get_appliance_tunnel_aliases,
+        get_appliance_tunnel_source_endpoints,
+        get_appliance_tunnels_config,
+        get_appliance_tunnels_config_and_state,
+        set_appliance_tunnels_ipsec_psk,
+        start_appliance_tunnel_mtu_discovery,
+    )

--- a/pyedgeconnect/__init__.py
+++ b/pyedgeconnect/__init__.py
@@ -1355,6 +1355,17 @@ class EdgeConnect(HttpCommon):
     from .ecos._peers import get_appliance_peers, get_appliance_peers_ec_only
     from .ecos._reboot import request_reboot
     from .ecos._save_changes import save_changes
+    from .ecos._security_maps import (
+        configure_appliance_security_policies,
+        delete_appliance_security_policy_rule,
+        delete_appliance_security_policy_zone_pair,
+        get_appliance_security_policies,
+        get_appliance_security_policy_map,
+        get_appliance_security_policy_settings,
+        get_appliance_security_policy_settings_by_map_name,
+        get_appliance_security_policy_zone_pair,
+        set_appliance_security_policy_settings,
+    )
     from .ecos._sp_portal import register_sp_portal, register_sp_portal_status
     from .ecos._statistics import (
         get_appliance_stats_minute_file,

--- a/pyedgeconnect/ecos/_alarm.py
+++ b/pyedgeconnect/ecos/_alarm.py
@@ -1,0 +1,272 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# alarm : Alarms
+from __future__ import annotations
+
+
+def get_appliance_alarms(
+    self,
+) -> dict:
+    """Return active alarms
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - alarm
+          - GET
+          - /alarm
+
+    :return: Returns summary of alarms and outstanding alarm details \n
+        * keyword **summary** (`dict`): Alarm summary object \n
+            * keyword **num_cleared** (`int`): Number of alarms cleared
+            * keyword **num_critical** (`int`): Number of critical
+              alarms
+            * keyword **num_equipment_outstanding** (`int`): Number of
+              hardware alarms outstanding
+            * keyword **num_major** (`int`): Number of major alarms
+            * keyword **num_minor** (`int`): Number of minor alarms
+            * keyword **num_outstanding** (`int`): Number of
+              outstanding alarms
+            * keyword **num_raise_ignore** (`int`): Number of raise
+              ignore
+            * keyword **num_software_outstanding** (`int`): Number of
+              software alarms outstanding
+            * keyword **num_tca_outstanding** (`int`): Number of TCA
+              alarms outstanding
+            * keyword **num_traffic_class_outstanding** (`int`): Number
+              of traffic class alarms outstanding
+            * keyword **num_tunnel_outstanding** (`int`): Number of
+              tunnel alarms outstanding
+            * keyword **num_warning** (`int`): Number of warning alarms
+        * keyword **outstanding* (`list[dict]`): Outstanding alarms \n
+            * [`dict`]: Outstanding Alarm detail object \n
+                * keyword **severity** (`int`): Alarm severity,
+                  ``0`` translates to ``Info``,
+                  ``1`` translates to ``Warning``,
+                  ``2`` translates to ``Minor``,
+                  ``3`` translates to ``Major``,
+                  ``4`` translates to ``Critical``,
+                * keyword **sequenceId** (`int`): Alarm sequence ID
+                * keyword **source** (`str`): Source IP address
+                * keyword **acknowledged** (`bool`): ``True`` if alarm
+                  has been acknowledged
+                * keyword **clearable** (`bool`): ``True`` if alarm
+                  can be cleared by user
+                * keyword **time** (`int`): Time alarm occured in unix
+                  epoch ms
+                * keyword **description** (`str`): Description of alarm
+                  detail
+                * keyword **type** (`str`): Hardware (``HW``) or
+                  Software (``SW``)
+                * keyword **recommendation** (`str`): Recommended action
+                  for alarm
+                * keyword **serviceAffect** (`bool`): ``True`` if
+                  condition could be service affecting
+                * keyword **typeId** (`int`): Alarm type ID number
+                * keyword **name** (`str`): Alarm name
+                * keyword **occurenceCount** (`int`): Count of
+                  occurences of alarm
+                * keyword **active** (`bool`): ``True`` if alarm is
+                  currently active
+                * keyword **ackedBy** (`str`): Username that
+                  acknolwedged alarm
+                * keyword **ackedTime** (`int`): Time of acknolwedgement
+                  in Unix epoch ms
+                * keyword **clearedBy** (`str`): Username that cleared
+                  alarm
+                * keyword **clearedTime** (`int`): Time of clear in Unix
+                  epoch ms
+                * keyword **note** (`str`): Additional alarm notes
+    :rtype: dict
+    """
+    return self._get("/alarm")
+
+
+def acknowledge_appliance_alarms(
+    self,
+    alarm_seq_ids: list[int],
+    acknowledge: bool,
+    ack_by: str,
+) -> bool:
+    """Acknowledge appliance alarms by sequence ids
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - alarm
+          - POST
+          - /alarm/acknowledgement
+
+    :param alarm_seq_ids: List of alarm sequence ids to acknowledge
+    :type alarm_seq_ids: list[int]
+    :param acknowledge: ``True`` to acknowledge alarms
+    :type acknowledge: bool
+    :param ack_by: User to mark alarms acknowledged by
+    :type ack_by: str
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    data = {
+        "sequenceIds": alarm_seq_ids,
+        "acknowledge": acknowledge,
+        "ackedBy": ack_by,
+    }
+
+    return self._post(
+        "/alarm/acknowledgement",
+        data=data,
+        return_type="bool",
+    )
+
+
+def clear_appliance_alarms(
+    self,
+    alarm_seq_ids: list[int],
+    cleared_by: str,
+) -> bool:
+    """Acknowledge appliance alarms by sequence ids
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - alarm
+          - POST
+          - /alarm/clearance
+
+    :param alarm_seq_ids: List of alarm sequence ids to clear
+    :type alarm_seq_ids: list[int]
+    :param cleared_by: User to mark alarms cleared by
+    :type cleared_by: str
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    data = {
+        "sequenceIds": alarm_seq_ids,
+        "clearedBy": cleared_by,
+    }
+
+    return self._post(
+        "/alarm/clearance",
+        data=data,
+        return_type="bool",
+    )
+
+
+def get_appliance_alarm_descriptions(
+    self,
+    format: str,
+) -> list:
+    """Get Orchestrator alarm descriptions
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - alarm
+          - GET
+          - /alarm/description2
+    :param format: Specify to ``csv`` to download CSV format, otherwise
+        will return information in list of dictionaries of JSON format
+    :type format: str
+    :return: Returns list of alarm descriptions and details \n
+        * [`dict`]: List of alarm description dictionaries \n
+            * keyword **typeId** (`int`): Alarm type id
+            * keyword **severity** (`str`): Alarm severity info
+            * keyword **description** (`str`): Alarm description
+            * keyword **recommendedAction** (`str`): recommended action
+            * keyword **serviceAffecting** (`bool`): Is alarm service
+              affecting
+            * keyword **source** (`str`): Module/system that generates
+              alarm
+            * keyword **systemType** (`int`): Identifies which system
+              generated the alaram.0 = Appliance,100 = Orchestartor
+            * keyword **sourceType** (`int`): Identifies the category of
+              alarm. ``1`` = Tunnel, ``2`` = Traffic Class, ``3`` =
+              Equipment, ``4`` = Software, ``5`` = Threshold
+            * keyword **alarmType** (`int`): Uniquely identifies the
+              type of alarm within a sourceType
+            * keyword **clearable** (`bool`): Identifies whether an
+              alarm is clearable
+    :rtype: dict
+    """
+    return self._get("/alarm/description2")
+
+
+def add_note_appliance_alarms(
+    self,
+    alarm_seq_ids: list[int],
+    note: str,
+) -> bool:
+    """Update notes on appliance alarms
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - alarm
+          - POST
+          - /alarm/note
+
+    :param alarm_seq_ids: List of alarm sequence ids to add note to
+    :type alarm_seq_ids: list[int]
+    :param note: Note to add to specified alarms
+    :type note: str
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    data = {
+        "sequenceIds": alarm_seq_ids,
+        "note": note,
+    }
+
+    return self._post(
+        "/alarm/note",
+        data=data,
+        return_type="bool",
+    )
+
+
+def delete_appliance_alarms(
+    self,
+    alarm_seq_ids: list[int],
+) -> bool:
+    """Delete alarms on appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - alarm
+          - POST
+          - /alarm/delete
+
+    :param alarm_seq_ids: List of alarm sequence ids to delete
+    :type alarm_seq_ids: list[int]
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    data = {
+        "sequenceIds": alarm_seq_ids,
+    }
+
+    return self._post(
+        "/alarm/delete",
+        data=data,
+        return_type="bool",
+    )

--- a/pyedgeconnect/ecos/_alarm.py
+++ b/pyedgeconnect/ecos/_alarm.py
@@ -42,7 +42,7 @@ def get_appliance_alarms(
             * keyword **num_tunnel_outstanding** (`int`): Number of
               tunnel alarms outstanding
             * keyword **num_warning** (`int`): Number of warning alarms
-        * keyword **outstanding* (`list[dict]`): Outstanding alarms \n
+        * keyword **outstanding** (`list[dict]`): Outstanding alarms \n
             * [`dict`]: Outstanding Alarm detail object \n
                 * keyword **severity** (`int`): Alarm severity,
                   ``0`` translates to ``Info``,
@@ -164,7 +164,7 @@ def clear_appliance_alarms(
 
 def get_appliance_alarm_descriptions(
     self,
-    format: str,
+    response_format: str = None,
 ) -> list:
     """Get Orchestrator alarm descriptions
 
@@ -177,9 +177,11 @@ def get_appliance_alarm_descriptions(
         * - alarm
           - GET
           - /alarm/description2
-    :param format: Specify to ``csv`` to download CSV format, otherwise
-        will return information in list of dictionaries of JSON format
-    :type format: str
+
+    :param response_format: Specify to ``csv`` to download CSV format,
+        otherwise will return information in list of dictionaries of
+        JSON format, defaults to None
+    :type response_format: str, optional
     :return: Returns list of alarm descriptions and details \n
         * [`dict`]: List of alarm description dictionaries \n
             * keyword **typeId** (`int`): Alarm type id
@@ -201,7 +203,12 @@ def get_appliance_alarm_descriptions(
               alarm is clearable
     :rtype: dict
     """
-    return self._get("/alarm/description2")
+    path = "/alarm/description2"
+
+    if response_format is not None:
+        path += f"?format={response_format}"
+
+    return self._get(path)
 
 
 def add_note_appliance_alarms(

--- a/pyedgeconnect/ecos/_bonded_tunnel.py
+++ b/pyedgeconnect/ecos/_bonded_tunnel.py
@@ -1,0 +1,681 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# bondedTunnel : Bonded Tunnels
+from __future__ import annotations
+
+
+def get_appliance_bonded_tunnels_state(
+    self,
+    state_match: str = None,
+) -> dict:
+    """Get the current list of tunnels and their configuration as well
+    as some state information like uptime and operational state
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - GET
+          - /bondedTunnels/state
+
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns dictionary of overlay tunnels with status matched
+        from the ``state_match`` parameter \n
+        * keyword **<bonded_tunnel_id>** (`dict`): Bonded tunnel object\n
+            * keyword **self** (`str`): Tunnel id
+            * keyword **oper** (`str`): Status, e.g. ``Up - Idle``
+            * keyword **uptime** (`int`): Tunnel uptime in ms
+            * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1488``
+            * keyword **cur_max_bw** (`str`): Tunnel max bw, Kbps
+            * keyword **rem_sys_bw** (`str`): Remaining system bandwidth
+            * keyword **quiescence** (`bool`): true,
+            * keyword **remote_id** (`int`): Remote ID
+            * keyword **state_bin** (`dict`): \n
+                * keyword **tun_state** (`str`): Tunnel status,
+                  e.g. ``Up - Idle``
+                * keyword **uptime** (`int`): Tunnel uptime in ms
+                * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1488``
+                * keyword **local_id** (`int`): Local ID
+                * keyword **bonded** (`bool`): Tunnel bonded state
+                * keyword **ipsec_nat_addr** (`str`): ``NONE`` for
+                  bonded tunnels
+                * keyword **ipsec_nat_port** (`str`): ``NONE`` for
+                  bonded tunnels
+    :rtype: dict
+    """
+    path = "/bondedTunnels/state"
+    if state_match is not None:
+        path += f"?state={state_match}"
+    return self._get(path)
+
+
+def get_appliance_multiple_bonded_tunnels_state(
+    self,
+    tunnel_list: list[str],
+) -> dict:
+    """Get multiple bonded tunnels state
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - POST
+          - /bondedTunnels/getStateMultiple
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns dictionary of specified tunnels queried \n
+        * keyword **<bonded_tunnel_id>** (`dict`): Bonded tunnel object\n
+            * keyword **self** (`str`): Tunnel id
+            * keyword **oper** (`str`): Status, e.g. ``Up - Idle``
+            * keyword **uptime** (`int`): Tunnel uptime in ms
+            * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1488``
+            * keyword **cur_max_bw** (`str`): Tunnel max bw, Kbps
+            * keyword **rem_sys_bw** (`str`): Remaining system bandwidth
+            * keyword **quiescence** (`bool`): true,
+            * keyword **remote_id** (`int`): Remote ID
+            * keyword **state_bin** (`dict`): \n
+                * keyword **tun_state** (`str`): Tunnel status,
+                  e.g. ``Up - Idle``
+                * keyword **uptime** (`int`): Tunnel uptime in ms
+                * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1488``
+                * keyword **local_id** (`int`): Local ID
+                * keyword **bonded** (`bool`): Tunnel bonded state
+                * keyword **ipsec_nat_addr** (`str`): ``NONE`` for
+                  bonded tunnels
+                * keyword **ipsec_nat_port** (`str`): ``NONE`` for
+                  bonded tunnels
+    :rtype: dict
+    """
+    return self._post(
+        "/bondedTunnels/getStateMultiple",
+        data=tunnel_list,
+    )
+
+
+def get_appliance_all_bonded_tunnel_ids(
+    self,
+    state_match: str = None,
+) -> list:
+    """Get the current list of all bonded tunnels
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - GET
+          - /bondedTunnels/allIDs
+
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns list of all tunnel ids
+        e.g. ``["bondedTunnel_370","bondedTunnel_371",...]``
+    :rtype: list
+    """
+    path = "/bondedTunnels/allIDs"
+    if state_match is not None:
+        path += f"?state={state_match}"
+    return self._get(path)
+
+
+def get_appliance_bonded_tunnel_aliases(
+    self,
+    limit: int,
+    alias_match: str = None,
+    state_match: str = None,
+) -> list:
+    """Find bonded tunnels with matching aliases on appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - GET
+          - /bondedTunnels/aliases
+
+    :param limit: Max number of tunnels to return from query
+    :type limit: int
+    :param alias_match: Match text of tunnel's alias, paramter is case
+        insensitive
+    :type alias_match: str
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns list of matching tunnels with tunnel ID and alias\n
+        * [`dict`]: List of tunnel alias/id pairs \n
+            * keyword **alias** (`str`): Tunnel alias
+            * keyword **id** (`str`): Tunnel id
+    :rtype: list
+    """
+    path = f"/bondedTunnels/aliases?limit={limit}"
+    if alias_match is not None:
+        path += f"&matchingAlias={alias_match}"
+    if state_match is not None:
+        path += f"&state={state_match}"
+    return self._get(path)
+
+
+def get_appliance_bonded_tunnels_config(
+    self,
+    state_match: str = None,
+) -> dict:
+    """Get the current list of bonded tunnels and their configuration
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - GET
+          - /bondedTunnels/config
+
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns dictionary of tunnels with status matched from the
+        ``state_match`` parameter \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **admin** (`str`): Admin state of the tunnel -
+              takes two values: ``up`` or ``down``
+            * keyword **alias** (`str`): Tunnel alias/name, e.g.
+              ``to_<REMOTE_EC_HOSTNAME>_<OVERLAY_NAME>``
+            * keyword **auto_mtu** (`bool`): Determines if the tunnel
+              should have auto MTU detection
+            * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+              marking \n
+                * keyword **dscp** (`str`): DSCP marking to be used on
+                  tunnel keepalive packets to determine if tunnel remote
+                  IP address is reachable
+            * keyword **gms_marked** (`bool`): ``True`` if configured by
+              Orchestrator
+            * keyword **gre_proto** (`int`): GRE protocol in the GRE
+              header
+            * keyword **id2** (`int`): NEEDS DESCRIPTION
+            * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+              not configurable
+            * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+              tunnel
+            * keyword **presharedkey** (`str`): Tunnel preshared key
+            * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+              source port
+            * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+              destination port
+            * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+            * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+              manually configured, use this field and set max_bw_auto to
+              ``false``
+            * keyword **max_bw_auto** (`bool`): If the tunnel max
+              bandwidth needs to be set to auto, this field must be true
+            * keyword **max_bw_unshaped** (`bool`): false,
+            * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+            * keyword **mode** (`str`): Tunnel mode, e.g. ``udp_sp``
+            * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1500``
+            * keyword **peername** (`str`): Tunnel peer name
+            * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+              ``auto``, ``none``
+            * keyword **pkt** (`dict`): Packet settings object \n
+                * keyword **coalesce_enable** (`bool`): Packet
+                  coalescing enabled
+                * keyword **coalesce_wait** (`int`): Packet coalescing
+                  wait timer
+                * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+                  ``enable``, ``disable``, or ``auto``
+                * keyword **fec_reset_intvl** (`int`): FEC reset
+                  interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+                * keyword **fec_max_ratio** (`int`): FEC auto maximum
+                  ration, e.g. ``10``
+                * keyword **fec_min_ratio** (`int`): FEC auto minimum
+                  ration, e.g. ``0``
+                * keyword **frag_enable** (`bool`): Enable tunnel packet
+                  fragmentation and reassembly
+                * keyword **reorder_wait** (`int`): Amount of time in ms
+                  to wait for Packet Order Correction algorithm
+            * keyword **tag_name** (`str`): Overlay name, e.g.
+              ``BulkApps``
+            * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+                * keyword **fastfail** (`int`): Enable fast fail,
+                  increasing the frequency of tunnel health packets,
+                  e.g. ``0``, ``1``, or ``2``
+                * keyword **fastfail-wait-base** (`int`): 150,
+                * keyword **fastfail-wait-rtt** (`int`): 5,
+                * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+                  not configured
+                * keyword **latency** (`int`): Latency threshold, ``0``
+                  if not configured
+                * keyword **loss** (`int`): Loss threshold, ``0`` if
+                  not configured
+                * keyword **retry_count** (`int`): How many packets
+                  which are sent once per second should be missed before
+                  a tunnel is declared down, e.g. ``3``
+            * keyword **type** (`str`): e.g. ``bonded``
+            * keyword **udp_dest_port** (`int`): If the tunnel is of
+              type 'udp', the udp port to use, e.g. ``4163``
+            * keyword **udp_flows** (`int`): If tunnel mode is udp, this
+              field determines how many different udp flows are used to
+              distribute tunnel traffic, e.g. ``256``
+            * keyword **local_vrf** (`int`): Local VRF ID, Default
+              segment would be ``0``
+            * keyword **source** (`str`): Source IP address of tunnel,
+              for bonded tunnels this is ``127.0.0.0``
+            * keyword **destination** (`str`): Destination IP address of
+              tunnel, for bonded tunnels this is ``127.0.0.0``
+            * keyword **bound_tun** (`dict`): Tunnels bound to bonded
+              tunnel \n
+                * keyword **<tunnel_id>** (`str`): Underlay tunnel alias
+                  e.g. ``to_<REMOTE_EC_HOSTNAME>_INET1-INET1``
+    :rtype: dict
+    """
+    path = "/bondedTunnels/config"
+    if state_match is not None:
+        path += f"?state={state_match}"
+    return self._get(path)
+
+
+def configure_appliance_all_bonded_tunnels(
+    self,
+    tunnel_configuration: dict,
+) -> bool:
+    """Add/modify overlay tunnels
+
+    .. warning::
+        This function would update all overlay tunnels. Existing tunnel
+        IDs will be updated, New tunnel IDs will be created.
+
+        Use :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnels_config`
+        to get current tunnel configuration
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - POST
+          - /bondedTunnels/config
+
+
+    :param tunnel_configuration: Dictionary structure for configuring
+        overlay tunnels on EdgeConnect appliance. See response from
+        :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnels_config`
+        for documentation of data structure
+    :type tunnel_configuration: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """  # noqa:W505,E501
+    return self._post(
+        "/bondedTunnels/config",
+        data=tunnel_configuration,
+        return_type="bool",
+    )
+
+
+def get_appliance_single_bonded_tunnel_config(
+    self,
+    tunnel_id: str,
+) -> dict:
+    """Get specific overlay tunnel configuration by tunnel id from
+    appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - GET
+          - /bondedTunnels/{id}
+
+    :param tunnel_id: Tunnel id of tunnel to retrieve information for,
+        e.g. ``bondedTunnel_385``
+    :type tunnel_id: str
+    :return: Returns dictionary of tunnel configuration for specific
+        tunnel \n
+        * keyword **admin** (`str`): Admin state of the tunnel -
+            takes two values: ``up`` or ``down``
+        * keyword **alias** (`str`): Tunnel alias/name, e.g.
+            ``to_<REMOTE_EC_HOSTNAME>_<OVERLAY_NAME>``
+        * keyword **auto_mtu** (`bool`): Determines if the tunnel
+            should have auto MTU detection
+        * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+            marking \n
+            * keyword **dscp** (`str`): DSCP marking to be used on
+                tunnel keepalive packets to determine if tunnel remote
+                IP address is reachable
+        * keyword **gms_marked** (`bool`): ``True`` if configured by
+            Orchestrator
+        * keyword **gre_proto** (`int`): GRE protocol in the GRE
+            header
+        * keyword **id2** (`int`): NEEDS DESCRIPTION
+        * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+            not configurable
+        * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+            tunnel
+        * keyword **presharedkey** (`str`): Tunnel preshared key
+        * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+            source port
+        * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+            destination port
+        * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+        * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+            manually configured, use this field and set max_bw_auto to
+            ``false``
+        * keyword **max_bw_auto** (`bool`): If the tunnel max
+            bandwidth needs to be set to auto, this field must be true
+        * keyword **max_bw_unshaped** (`bool`): false,
+        * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+        * keyword **mode** (`str`): Tunnel mode, e.g. ``udp_sp``
+        * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1500``
+        * keyword **peername** (`str`): Tunnel peer name
+        * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+            ``auto``, ``none``
+        * keyword **pkt** (`dict`): Packet settings object \n
+            * keyword **coalesce_enable** (`bool`): Packet
+                coalescing enabled
+            * keyword **coalesce_wait** (`int`): Packet coalescing
+                wait timer
+            * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+                ``enable``, ``disable``, or ``auto``
+            * keyword **fec_reset_intvl** (`int`): FEC reset
+                interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+            * keyword **fec_max_ratio** (`int`): FEC auto maximum
+                ration, e.g. ``10``
+            * keyword **fec_min_ratio** (`int`): FEC auto minimum
+                ration, e.g. ``0``
+            * keyword **frag_enable** (`bool`): Enable tunnel packet
+                fragmentation and reassembly
+            * keyword **reorder_wait** (`int`): Amount of time in ms
+                to wait for Packet Order Correction algorithm
+        * keyword **tag_name** (`str`): Overlay name, e.g.
+            ``BulkApps``
+        * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+            * keyword **fastfail** (`int`): Enable fast fail,
+                increasing the frequency of tunnel health packets,
+                e.g. ``0``, ``1``, or ``2``
+            * keyword **fastfail-wait-base** (`int`): 150,
+            * keyword **fastfail-wait-rtt** (`int`): 5,
+            * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+                not configured
+            * keyword **latency** (`int`): Latency threshold, ``0``
+                if not configured
+            * keyword **loss** (`int`): Loss threshold, ``0`` if
+                not configured
+            * keyword **retry_count** (`int`): How many packets
+                which are sent once per second should be missed before
+                a tunnel is declared down, e.g. ``3``
+        * keyword **type** (`str`): e.g. ``bonded``
+        * keyword **udp_dest_port** (`int`): If the tunnel is of
+            type 'udp', the udp port to use, e.g. ``4163``
+        * keyword **udp_flows** (`int`): If tunnel mode is udp, this
+            field determines how many different udp flows are used to
+            distribute tunnel traffic, e.g. ``256``
+        * keyword **local_vrf** (`int`): Local VRF ID, Default
+            segment would be ``0``
+        * keyword **source** (`str`): Source IP address of tunnel,
+            for bonded tunnels this is ``127.0.0.0``
+        * keyword **destination** (`str`): Destination IP address of
+            tunnel, for bonded tunnels this is ``127.0.0.0``
+        * keyword **bound_tun** (`dict`): Tunnels bound to bonded
+            tunnel \n
+            * keyword **<tunnel_id>** (`str`): Underlay tunnel alias
+                e.g. ``to_<REMOTE_EC_HOSTNAME>_INET1-INET1``
+    :rtype: dict
+    """
+    return self._get(f"/bondedTunnels/config/{tunnel_id}")
+
+
+def delete_appliance_single_bonded_tunnel(
+    self,
+    tunnel_id: str,
+) -> bool:
+    """Delete specific overlay tunnel configuration by tunnel id from
+    appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - DELETE
+          - /bondedTunnels/config/{id}
+
+    :param tunnel_id: Tunnel id of tunnel to retrieve information for,
+        e.g. ``bondedTunnel_385``
+    :type tunnel_id: str
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._delete(
+        f"/bondedTunnels/config/{tunnel_id}",
+        return_type="bool",
+    )
+
+
+def get_appliance_multiple_bonded_tunnels_config(
+    self,
+    tunnel_list: list[str],
+) -> dict:
+    """Get the configuration of multiple bonded tunnels from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - POST
+          - /bondedTunnels/getMultiple
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns dictionary of specified tunnels queried \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **admin** (`str`): Admin state of the tunnel -
+              takes two values: ``up`` or ``down``
+            * keyword **alias** (`str`): Tunnel alias/name, e.g.
+              ``to_<REMOTE_EC_HOSTNAME>_<OVERLAY_NAME>``
+            * keyword **auto_mtu** (`bool`): Determines if the tunnel
+              should have auto MTU detection
+            * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+              marking \n
+                * keyword **dscp** (`str`): DSCP marking to be used on
+                  tunnel keepalive packets to determine if tunnel remote
+                  IP address is reachable
+            * keyword **gms_marked** (`bool`): ``True`` if configured by
+              Orchestrator
+            * keyword **gre_proto** (`int`): GRE protocol in the GRE
+              header
+            * keyword **id2** (`int`): NEEDS DESCRIPTION
+            * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+              not configurable
+            * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+              tunnel
+            * keyword **presharedkey** (`str`): Tunnel preshared key
+            * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+              source port
+            * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+              destination port
+            * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+            * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+              manually configured, use this field and set max_bw_auto to
+              ``false``
+            * keyword **max_bw_auto** (`bool`): If the tunnel max
+              bandwidth needs to be set to auto, this field must be true
+            * keyword **max_bw_unshaped** (`bool`): false,
+            * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+            * keyword **mode** (`str`): Tunnel mode, e.g. ``udp_sp``
+            * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1500``
+            * keyword **peername** (`str`): Tunnel peer name
+            * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+              ``auto``, ``none``
+            * keyword **pkt** (`dict`): Packet settings object \n
+                * keyword **coalesce_enable** (`bool`): Packet
+                  coalescing enabled
+                * keyword **coalesce_wait** (`int`): Packet coalescing
+                  wait timer
+                * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+                  ``enable``, ``disable``, or ``auto``
+                * keyword **fec_reset_intvl** (`int`): FEC reset
+                  interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+                * keyword **fec_max_ratio** (`int`): FEC auto maximum
+                  ration, e.g. ``10``
+                * keyword **fec_min_ratio** (`int`): FEC auto minimum
+                  ration, e.g. ``0``
+                * keyword **frag_enable** (`bool`): Enable tunnel packet
+                  fragmentation and reassembly
+                * keyword **reorder_wait** (`int`): Amount of time in ms
+                  to wait for Packet Order Correction algorithm
+            * keyword **tag_name** (`str`): Overlay name, e.g.
+              ``BulkApps``
+            * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+                * keyword **fastfail** (`int`): Enable fast fail,
+                  increasing the frequency of tunnel health packets,
+                  e.g. ``0``, ``1``, or ``2``
+                * keyword **fastfail-wait-base** (`int`): 150,
+                * keyword **fastfail-wait-rtt** (`int`): 5,
+                * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+                  not configured
+                * keyword **latency** (`int`): Latency threshold, ``0``
+                  if not configured
+                * keyword **loss** (`int`): Loss threshold, ``0`` if
+                  not configured
+                * keyword **retry_count** (`int`): How many packets
+                  which are sent once per second should be missed before
+                  a tunnel is declared down, e.g. ``3``
+            * keyword **type** (`str`): e.g. ``bonded``
+            * keyword **udp_dest_port** (`int`): If the tunnel is of
+              type 'udp', the udp port to use, e.g. ``4163``
+            * keyword **udp_flows** (`int`): If tunnel mode is udp, this
+              field determines how many different udp flows are used to
+              distribute tunnel traffic, e.g. ``256``
+            * keyword **local_vrf** (`int`): Local VRF ID, Default
+              segment would be ``0``
+            * keyword **source** (`str`): Source IP address of tunnel,
+              for bonded tunnels this is ``127.0.0.0``
+            * keyword **destination** (`str`): Destination IP address of
+              tunnel, for bonded tunnels this is ``127.0.0.0``
+            * keyword **bound_tun** (`dict`): Tunnels bound to bonded
+              tunnel \n
+                * keyword **<tunnel_id>** (`str`): Underlay tunnel alias
+                  e.g. ``to_<REMOTE_EC_HOSTNAME>_INET1-INET1``
+    :rtype: dict
+    """
+    return self._post(
+        "/bondedTunnels/getMultiple",
+        data=tunnel_list,
+    )
+
+
+def delete_appliance_multiple_bonded_tunnels(
+    self,
+    tunnel_list: list[str],
+) -> dict:
+    """Delete multiple bonded tunnels from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - POST
+          - /bondedTunnels/deleteMultiple
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._post(
+        "/bondedTunnels/deleteMultiple",
+        data=tunnel_list,
+    )
+
+
+def get_appliance_bonded_tunnel_live_view_info(
+    self,
+    tunnel_id: str,
+) -> dict:
+    """Get Live View state information for specific overlay tunnel
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - bondedTunnel
+          - POST
+          - /liveViewInfo/{id}
+
+    :param tunnel_id: Tunnel id of tunnel to retrieve information for,
+        e.g. ``bondedTunnel_385``
+    :type tunnel_id: str
+    :return: Returns dictionary of Live View state information for
+        overlay tunnel queried \n
+        * keyword **state_bin** (`dict`): Status object \n
+            * keywoord **tun_state** (`str`): Tunnel status, e.g.
+              ``Up - Idle``
+            * keyword **overlay** (`dict`): Overlay live view stats \n
+                * keyword **black_tun_list** (`list[str]`): List of
+                  tunnels exlcluded from overlay due to blackout
+                  conditions
+                * keyword **black_reason_fastfail** (`list[str]`): List
+                  of tunnels excluded from overlay due to fast fail
+                  blackout
+                * keyword **brown_tun_list** (`list[str]`): List of
+                  tunnels in brownout status
+                * keyword **brown_reason_loss** (`list[str]`): List of
+                  tunnels in brownout status because of loss
+                * keyword **brown_reason_latency** (`list[str]`): List
+                  of tunnels in brownout status because of latency
+                * keyword **brown_reason_jitter** (`list[str]`): List of
+                  tunnels in brownout status because of jitter
+                * keyword **green_tun_list** (`list[str]`): List of
+                  underlay tunnels in green status
+                * keyword **curr_tun_list** (`list[str]`): List of
+                  underlay tunnels currently in use
+                * keyword **best_link** (`str`): Current best performing
+                  underlay tunnel, e.g. ``tunnel_404``
+                * keyword **ts** (`int`): Unix epoch timestamp in ms
+                * keyword **bonded_tunnel_state_brown** (`int`):
+                  Overall overlay tunnel brownout status, ``0`` for
+                  green, ``1`` for brownout
+                * keyword **bonded_tunnel_state_brown_lat** (`int`):
+                  overlay tunnel brownout status due to latency, ``0``
+                  for green, ``1`` for brownout
+                * keyword **bonded_tunnel_state_brown_loss** (`int`):
+                  overlay tunnel brownout status due to loss, ``0``
+                  for green, ``1`` for brownout
+                * keyword **bonded_tunnel_state_brown_jit** (`int`):
+                  overlay tunnel brownout status due to jitter, ``0``
+                  for green, ``1`` for brownout
+    """
+    return self._get(f"/liveViewInfo/{tunnel_id}")

--- a/pyedgeconnect/ecos/_bonded_tunnel.py
+++ b/pyedgeconnect/ecos/_bonded_tunnel.py
@@ -49,7 +49,7 @@ def get_appliance_bonded_tunnels_state(
                 * keyword **ipsec_nat_port** (`str`): ``NONE`` for
                   bonded tunnels
     :rtype: dict
-    """
+    """  # noqa: W505
     path = "/bondedTunnels/state"
     if state_match is not None:
         path += f"?state={state_match}"
@@ -96,7 +96,7 @@ def get_appliance_multiple_bonded_tunnels_state(
                 * keyword **ipsec_nat_port** (`str`): ``NONE`` for
                   bonded tunnels
     :rtype: dict
-    """
+    """  # noqa: W505
     return self._post(
         "/bondedTunnels/getStateMultiple",
         data=tunnel_list,
@@ -595,7 +595,7 @@ def get_appliance_multiple_bonded_tunnels_config(
 def delete_appliance_multiple_bonded_tunnels(
     self,
     tunnel_list: list[str],
-) -> dict:
+) -> bool:
     """Delete multiple bonded tunnels from appliance
 
     .. list-table::
@@ -616,6 +616,7 @@ def delete_appliance_multiple_bonded_tunnels(
     return self._post(
         "/bondedTunnels/deleteMultiple",
         data=tunnel_list,
+        return_type="bool",
     )
 
 

--- a/pyedgeconnect/ecos/_cli.py
+++ b/pyedgeconnect/ecos/_cli.py
@@ -1,0 +1,67 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# cli : API to execute commands on appliance CLI
+from __future__ import annotations
+
+
+def perform_appliance_cli_command(
+    self,
+    cli_command: str,
+) -> str:
+    """Run single cli command on appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - cli
+          - POST
+          - /cli
+
+    :param cli_command: CLI command to perform on appliance, e.g.
+        ``show subnet learned``
+    :type cli_command: str
+    :return: Returns text response of cli command
+    :rtype: str
+    """
+    data = {"command": cli_command}
+    return self._post(
+        "/cli",
+        data=data,
+        return_type="text",
+    )
+
+
+def perform_appliance_multiple_cli_command(
+    self,
+    cli_commands: list[str],
+) -> list:
+    """Run multiple cli commands on appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - cli
+          - POST
+          - /cliMultiple
+
+    :param cli_commands: List of CLI command to perform on appliance,
+        e.g. ``["show version", "show transceiver"]``
+    :type cli_command: list[str]
+    :return: Returns list of dictionaries of reuslts for each command \n
+        * [`list[dict]`]: List of command results \n
+            * keyword **command** (`str`): Cli command run
+            * keyword **result** (`str`): Text result from cli command
+    :rtype: list
+    """
+    data = {"commands": cli_commands}
+    return self._post(
+        "/cliMultiple",
+        data=data,
+    )

--- a/pyedgeconnect/ecos/_deployment.py
+++ b/pyedgeconnect/ecos/_deployment.py
@@ -1,0 +1,367 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# deployment : Deployment configuration
+
+
+def get_appliance_deployment(
+    self,
+) -> dict:
+    """Get the deployment configuration of the appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - deployment
+          - GET
+          - /deployment
+
+    :param ne_pk: Network Primary Key (nePk) of existing appliance,
+        e.g. ``3.NE``
+    :type ne_pk: str
+    :return: Returns dictionary of appliance deployment information \n
+        * keyword **scalars** (`dict`): Scalars object, example values
+          included below \n
+            * keyword **maxWanBandwidth** (`int`): 200000
+            * keyword **defaultMaxWanBandwidth** (`int`): 200000
+            * keyword **maxRxTargetBandwidth** (`int`): 2000000
+            * keyword **maxTunnels** (`int`): 2000
+            * keyword **maxIKETunnels** (`int`): 4000
+            * keyword **minMtu** (`int`): 700
+            * keyword **maxMtu** (`int`): 9000
+            * keyword **maxRouteMaps** (`int`): 10
+            * keyword **maxOptMaps** (`int`): 10
+            * keyword **maxQoSMaps** (`int`): 10
+            * keyword **maxNatMaps** (`int`): 10
+            * keyword **maxRouteMapEntries** (`int`): 2000
+            * keyword **maxOptMapEntries** (`int`): 200
+            * keyword **maxQoSMapEntries** (`int`): 200
+            * keyword **maxNatMapEntries** (`int`): 300
+            * keyword **isPortalLicensed** (`bool`): true
+            * keyword **portalLicenseType** (`int`): 2
+            * keyword **supportServerMode** (`bool`): true
+            * keyword **isLicenseRequired** (`bool`): false
+            * keyword **isDynamicLimits** (`bool`): true
+            * keyword **isDynamicInterface** (`bool`): true
+            * keyword **isModel4Port** (`bool`): true
+            * keyword **isModel10G** (`bool`): false
+            * keyword **isModelSingleDisk** (`bool`): true
+            * keyword **isModelPowerCycle** (`bool`): false
+            * keyword **num1GigPorts** (`int`): 32
+            * keyword **num1GigFiberPorts** (`int`): 0
+            * keyword **numMgmtPorts** (`int`): 2
+            * keyword **num10GigPorts** (`int`): 0
+            * keyword **isGMSCompatible** (`bool`): true
+            * keyword **maxAcls** (`int`): 100
+            * keyword **maxAclEntries** (`int`): 100
+            * keyword **maxUDAs** (`int`): 200
+            * keyword **maxUDAEntries** (`int`): 400
+            * keyword **maxVLANs** (`int`): 127
+            * keyword **maxSubInterfaces** (`int`): 127
+            * keyword **diskLayout** (`str`): ""
+            * keyword **vrrpCompatible** (`bool`): false
+            * keyword **supportsBridgeLoopTest** (`bool`): true
+            * keyword **supportsDiskSelfTest** (`bool`): true
+            * keyword **supportsBypass** (`bool`): false
+            * keyword **isNMInDisklessMode** (`bool`): false
+            * keyword **nmDiskSize** (`int`): 70
+            * keyword **processorCount** (`int`): 2
+            * keyword **memorySize** (`int`): 6
+            * keyword **cacheDiskCount** (`int`): 0
+            * keyword **spindleDiskCount** (`int`): 1
+            * keyword **maxFlows** (`int`): 128000
+            * keyword **maxRedFlows** (`int`): 1024000
+            * keyword **maxBypassFlows** (`int`): 1024000
+            * keyword **actualProcessorCount** (`int`): 2
+            * keyword **actualMemorySize** (`int`): 6
+            * keyword **actualNMDiskSize** (`int`): 70
+            * keyword **isModelForReplication** (`bool`): false
+            * keyword **maxIpServiceEntries** (`int`): 1000000
+            * keyword **maxSaasEntries** (`int`): 256000
+            * keyword **maxOverlays** (`int`): 7
+            * keyword **maxSegMapEntries** (`int`): 2000
+            * keyword **maxDnsProxySegments** (`int`): 4
+            * keyword **maxRoutemaps** (`int`): 10
+            * keyword **maxOptmaps** (`int`): 10
+            * keyword **maxQosmaps** (`int`): 10
+            * keyword **maxNatmaps** (`int`): 10
+            * keyword **maxAcmaps** (`int`): 10
+            * keyword **maxPolicymaps** (`int`): 70
+            * keyword **maxMapnamelen** (`int`): 32
+            * keyword **maxRulesperacl** (`int`): 100
+            * keyword **maxAclrulelen** (`int`): 1024
+            * keyword **isIdsSupported** (`bool`): false
+        * keyword **sysConfig** (`dict`): Appliance's system
+          configuration \n
+            * keyword **mode** (`str`):  System deployment mode,
+              ``bridge`` or ``router``
+            * keyword **useMgmt0** (`bool`): Use mgmt0 interface as a
+              datapath interface as well. (only valid under router mode)
+            * keyword **tenG** (`bool`): Use 10Gbps interfaces (only
+              valid for models with 10Gbps interfaces)
+            * keyword **bonding** (`bool`): Use interface bonding (only
+              valid for models with 2 LAN interfaces and 2 WAN
+              interfaces)
+            * keyword **maxBW** (`int`): System maximum bandwidth in
+              Kbps
+            * keyword **propagateLinkDown** (`bool`): Propagate link
+              down state: this is valid in bridge mode only. If it is
+              true, if either LAN or WAN side interface of the bridge is
+              down, the system brings down the other interface
+              automatically
+            * keyword **singleBridge** (`bool`): Single 4-port flat
+              bridge configuration (only valid for 4-port models)
+            * keyword **inline** (`bool`): Inline router mode (only
+              valid for router mode). This is the recommended mode.
+            * keyword **ifLabels** (`dict`): interface labels \n
+                * keyword **lan** (`list[dict]`): Available LAN
+                  interface labels \n
+                    * [`dict`]: interface detail \n
+                        * keyword **id** (`str`): Unique label ID
+                        * keyword **name** (`str`): Label name eg:
+                          ``Voice``, ``Data``, ``MPLS``...
+                * keyword **wan** (`list[dict]`): Available WAN
+                  interface labels \n
+                    * [`dict`]: interface detail \n
+                        * keyword **id** (`str`): Unique label ID
+                        * keyword **name** (`str`): Label name eg:
+                          ``Voice``, ``Data``, ``MPLS``...
+            * keyword **haIf** (`str`): Name of the interface used to
+              build 'internal' High Availability (HA) VLAN interfaces
+              using which two appliances in a HA configuration can
+              communicate with each other
+            * keyword **maxInBW** (`int`): System maximum inbound
+              bandwidth in Kbps (to enable inbound shaping make sure
+              maxInBWEnabled is set to true)
+            * keyword **maxInBWEnabled** (`bool`): Enable inbound
+              bandwidth shaping (if this is true, you must specify
+              maxInBW)
+            * keyword **licence** (`dict`): Appliance EC license
+              information (only valid for EC models) \n
+                * keyword **ecMini** (`bool`): Is EC Mini license
+                  enabled
+                * keyword **ecPlus** (`bool`): Is EC Plus license
+                  enabled
+                * keyword **ecTier** (`str`): EC Tier license name
+                * keyword **ecTierBW** (`int`): EC Tier bandwidth in
+                  Kbps
+                * keyword **ecBoost** (`bool`): Is EC Boost license
+                  enabled
+                * keyword **ecBoostBW** (`int`): Boost bandwidth in
+                  Kbps
+                * keyword **<license_type>** (`dict`, optional): This
+                  key is dynamic based on the EC license type (``fx``,
+                  ``ecsp`` etc). Contains additional details based on
+                  license type.
+            * keyword **zones** (`list[dict]`): Firewall zones \n
+                * [`dict`]: FW Zones object \n
+                    * keyword **id** (`int`): Zone ID, e.g. ``1``
+                    * keyword **name** (`str`): Zone name,
+                      e.g. ``Public``
+            * keyword **vrfs** (`list[dict]`): VRF segments \n
+                * [`dict`]: VRF segments object \n
+                    * keyword **id** (`int`): VRF ID, e.g. ``0``
+                    * keyword **name** (`str`): VRF name,
+                      e.g. ``Default``
+            * keyword **vrfZonesMap** (`dict`): Mapping of zone ids
+              and corresponding VRFs \n
+                * keyword **<vrf_id>** (`dict`): VRF mapping \n
+                    * keyword **<zone_id>** (`dict`): Zone mapping \n
+                        * keyword **id** (`int`): Zone ID, e.g. ``1``
+                        * keyword **name** (`str`): Zone name,
+                          e.g. ``Public``
+        * keyword **mgmtIfData** (`dict`): Appliance's management
+          network interfaces information \n
+            * keyword **<mgmt_interface>** (`dict`): mgmt object \n
+                * keyword **dhcp** (`bool`): Is DHCP on or off on this
+                  management interface
+                * keyword **nexthop** (`str`): Management interface
+                  gateway IP address
+                * keyword **ip** (`str`): Management interface IP
+                  address
+                * keyword **mask** (`int`): Management interface network
+                  mask
+        * keyword **modeIfs** (`list[dict]`): Interface details \n \n
+            * keyword **devNum** (`str`): Deployment interface type,
+              rtr1/rtr2, bdg1/bdg2, only for UI use, not needed in POST
+            * keyword **ifName** (`str`): Deployment interface name,
+              wan0/lan0 for router mode, bvi0/bvi1 for bridge mode
+            * keyword **applianceIPs** (`list[dict]`): Deployment
+              interface IP addresses assignment \n
+                * [`dict`]: Interface object \n
+                    * keyword **ip** (`str`): Appliance interface IP
+                      address
+                    * keyword **mask** (`int`): IP address network mask
+                    * keyword **subif** (`str`): Sub-interface ID
+                    * keyword **vlan** (`str`): VLAN ID
+                    * keyword **wanNexthop** (`str`): Next hop IP
+                      address
+                    * keyword **label** (`str`): Interface label
+                      assigned to this interface
+                    * keyword **lanSide** (`bool`): Determines if this
+                      interface is on LAN side
+                    * keyword **wanSide** (`bool`): Determines if this
+                      interface is on WAN side
+                    * keyword **dhcp** (`bool`): Determines if DHCP is
+                      enabled for this interface (only applicable for
+                      WAN side main interface IPs in inline router mode)
+                    * keyword **harden** (`int`): Determines if this
+                      interface has firewall configured (only applicable
+                      for WAN side main/VLAN interfaces in router mode).
+                      Valid values are 0:Allow All, 1:Hardened,
+                      2:Stateful, 3:Stateful+SNAT
+                    * keyword **behindNAT** (`str`): Determines if this
+                      interface is connected to a Network Address
+                      Translation device (only applicable to WAN
+                      interfaces). Valid values are 'auto', 'none', ''.
+                      'auto' means interface is behind a NAT device.
+                      'none' or '' mean interface is NOT behind a NAT
+                      device
+                    * keyword **maxBW** (`dict`): Maximum
+                      inbound/outbound bandwidth for this interface in
+                      Kbps (only applicable to WAN interfaces) \n
+                        * keyword **inbound** (`int`): Maximum inbound
+                          (WAN to LAN) bandwidth for this interface in
+                          Kbps
+                        * keyword **outbound** (`int`): Maximum outbound
+                          (LAN to WAN) bandwidth for this interface in
+                          Kbps
+                    * keyword **dhcpd** (`dict`): Interface DHCP
+                      (server/relay) configuration (only applicable
+                      to LAN interfaces in inline router mode) \n
+                        * keyword **type** (`str`): Enum to determine if
+                          this LAN interface is acting like a DHCP
+                          server, relay or none. Valid values are
+                          ``server``, ``relay``, ``none``
+                        * keyword **server** (`dict`): DHCP server
+                          related configuration \n
+                            * keyword **prefix** (`str`): DHCP server
+                              subnet and mask value
+                              e.g. ``10.3.171.0/24``
+                            * keyword **ipStart** (`str`): IP within the
+                              DHCP server subnet from where to start
+                              allocating IPs
+                            * keyword **ipEnd** (`str`): IP within the
+                              DHCP server subnet till where IPs can be
+                              allocated
+                            * keyword **gw** (`list[str]`): Gateway IP
+                              Address
+                            * keyword **dns** (`list[str]`): DNS
+                              server(s) IP Address
+                            * keyword **ntpd** (`list[str]`): NTP
+                              server(s) IP Address
+                            * keyword **netbios** (`list[str]`): NetBIOS
+                              name server(s) IP Address
+                            * keyword **netbiosNodeType** (`str`): Enum
+                              denoting the type of NetBIOS server. Valid
+                              values are ``B``, ``P``, ``M``, ``H``
+                            * keyword **maxLease** (`int`): Maximum
+                              lease time in seconds
+                            * keyword **defaultLease** (`int`): Default
+                              lease time in seconds
+                            * keyword **options** (`dict`): Object
+                              containing dynamic DHCP options \n
+                                * keyword **<option_id>** (`str`):
+                                  option value
+                            * keyword **host** (`dict`): Object
+                              containing list of hosts with static IP
+                              reservations \n
+                                * keyword **<hostname>** (`dict`): \n
+                                    * keyword **mac** (`str`): MAC
+                                      address
+                                    * keyword **ip** (`str`): IP address
+                            * keyword **failover** (`bool`): Determine
+                              if appliance enable DHCP failover
+                        * keyword **relay** (`dict`): DHCP relay related
+                          configuration \n
+                            * keyword **dhcpserver** (`list[str]`):
+                              Array of destination DHCP server IP
+                              addresses
+                            * keyword **option82** (`bool`): Determine
+                              whether option 82 is enabled
+                            * keyword **option82_policy** (`str`): Enum
+                              to determine option 82 policy used if
+                              option 82 is enabled. Valid values are
+                              ``append``, ``replace``, ``forward``,
+                              ``discard``
+                    * keyword **brifs** (`dict`): Bridge
+                      interface configurations \n
+                        * keyword **<interface>** (`dict`): brif
+                          object \n
+                            * keyword **label** (`str`): Bridge lan/wan
+                              side interface label
+                            * keyword **harden** (`str`): Firewall
+                              configuration for bridge interface. Valid
+                              values are 0:Allow All, 1:Hardened,
+                              2:Stateful, 3:Stateful+SNAT
+                            * keyword **wanSide** (`bool`): This bridge
+                              interface is on WAN side
+                            * keyword **lanSide** (`bool`): This bridge
+                              interface is on LAN side
+                            * keyword **comment** (`str`): User comments
+                    * keyword **zone** (`int`): Zone id assigned to
+                      this interface. 0 if no zone assigned
+                    * keyword **vrf** (`int`): VRF segment id assigned
+                      to this interface. 0 if default VRF segment is
+                      assigned
+                    * keyword **comment** (`str`): User comments
+                    * keyword **failover** (`bool`): Determine if
+                      appliance enable DHCP failover
+        * keyword **dpRoutes** (`list[dict]`): \n
+            * [`dict`]: dpRoutes object \n
+                * keyword **prefix** (`str`): Subnetwork prefix, for
+                  example, ``2.2.2.0/24``
+                * keyword **nexthop** (`str`): Next hop IP address for
+                  this route entry
+                * keyword **intf** (`str`): Interface name for this
+                  route entry, auto or bvi0/bvi1/VLAN for bridge mode
+                * keyword **metric** (`int`): Routing metric value,
+                  lower values have higher priority
+                * keyword **type** (`str`): Route entry type, gw is the
+                  only option for now
+        * keyword **vifs** (`dict`): vifs object \n
+            * keyword **pppoe** (`list[str]`): List of PPPoE interface
+              names configured on this appliance
+            * keyword **bondedIfs** (`list[str]`): List of bonded
+              interfaces configured on this appliance
+        * keyword **dhcpFailover** (`dict`): DHCP failover config \n
+            * keyword **<interface>** (`dict`): interface dhcp failover
+              config \n
+                * keyword **max_unack_updates** (`int`): Tells the
+                  remote DHCP server how many BNDUPD messages it can
+                  send before it receives a BNDACK from the local system
+                * keyword **peer_port** (`int`): Define which TCP port
+                  to connect to its failover peer for failover messages
+                * keyword **my_port** (`int`): Defines which TCP port
+                  the server should listen for connections from its
+                  failover peer
+                * keyword **max_resp_delay** (`int`): Tells the DHCP
+                  server how many seconds may pass without receiving a
+                  message from its failover peer before it assumes that
+                  connection has failed
+                * keyword **load_bal_max** (`int`): Defines a threshold
+                  to compare with the secs field of the client's DHCP
+                  packet in order to override load balancing
+                * keyword **role** (`str`) = Specify if the server is
+                  the primary or secondary, ``primary`` or ``secondary``
+                * keyword **mclt** (`int`): Define the Maximum Client
+                  Lead Time
+                * keyword **split** (`int`): Specify the split between
+                  the primary and secondary
+                * keyword **peer_ip** (`str`): Define which server it
+                  should connect to reach its failover peer
+                * keyword **my_ip** (`str`): Define the address that the
+                  server should listen for connections from its failover
+                  peer
+    :rtype: dict
+    """
+    return self._get("/deployment")
+
+
+# TODO - POST /deployment
+#      - Modify the deployment settings
+# TODO - POST /deployment/validate
+#      - Validate deployment configuration

--- a/pyedgeconnect/ecos/_local_subnets.py
+++ b/pyedgeconnect/ecos/_local_subnets.py
@@ -195,9 +195,10 @@ def get_appliance_subnets_all_vrfs(self) -> dict:
         * keyword **subnets** (`dict`): Subnet object \n
             * keyword **<vrf_id>** (`dict`): Subnets in Segment/VRF \n
                 * keyword **count** (`int`): Count of all subnets
-                * keyword **max** (`int`): Max subnets IPv4 & IPv6, 60000
-                * keyword **entries** (`list[dict]`): List of subnet detail
-                  objects \n
+                * keyword **max** (`int`): Max subnets IPv4 & IPv6,
+                  60000
+                * keyword **entries** (`list[dict]`): List of subnet
+                  detail objects \n
                     * keyword **state** (`dict`): Subnet detail object\n
                         * keyword **version** (`int`): IP Version, e.g.
                           ``4`` or ``6``
@@ -235,8 +236,8 @@ def get_appliance_subnets_all_vrfs(self) -> dict:
                           OSPF
                         * keyword **learned_bgp** (`bool`): Learned from
                           BGP
-                        * keyword **learned_ospf** (`bool`): Learned from
-                          OSPF
+                        * keyword **learned_ospf** (`bool`): Learned
+                          from OSPF
                         * keyword **state** (`str`): State of route,
                           e.g. ``UP`` or ``DOWN``
                         * keyword **routeTag** (`str`): Tag on route,
@@ -259,7 +260,8 @@ def get_appliance_subnets_all_vrfs(self) -> dict:
                           message
                         * keyword **zone_id** (`str`): Firewall zone id
                           for route, e.g. ``0`` for Default
-                        * keyword **advOSPFTag** (`str`): Advertise OSPF tag
+                        * keyword **advOSPFTag** (`str`): Advertise OSPF
+                          tag
                         * keyword **routeType** (`str`): Type of route
                           e.g. ``EBGP``
                         * keyword **saasAppName** (`str`): SaaS
@@ -554,7 +556,8 @@ def get_appliance_locally_configured_subnets(self) -> dict:
         * keyword **prefix** (`dict`): Subnets object \n
             * keyword **<ip_and_mask>** (`dict`): Object for this
               prefix, e.g. key value ``10.1.1.0/24`` \n
-                * keyword **self** (`int`): Max subnets IPv4 & IPv6, 60000
+                * keyword **self** (`int`): Max subnets IPv4 & IPv6,
+                  60000
                 * keyword **advert** (`bool`): If route is advertised
                 * keyword **advert_bgp** (`bool`): If route is
                   advertised to BGP
@@ -686,7 +689,8 @@ def get_appliance_locally_configured_subnets_single_vrf(
         * keyword **prefix** (`dict`): Subnets object \n
             * keyword **<ip_and_mask>** (`dict`): Object for this
               prefix, e.g. key value ``10.1.1.0/24`` \n
-                * keyword **self** (`int`): Max subnets IPv4 & IPv6, 60000
+                * keyword **self** (`int`): Max subnets IPv4 & IPv6,
+                  60000
                 * keyword **advert** (`bool`): If route is advertised
                 * keyword **advert_bgp** (`bool`): If route is
                   advertised to BGP

--- a/pyedgeconnect/ecos/_local_subnets.py
+++ b/pyedgeconnect/ecos/_local_subnets.py
@@ -1,0 +1,1020 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# localSubnets : Local subnets
+from __future__ import annotations
+
+
+def get_appliance_subnets(self) -> dict:
+    """Gets all configured, learned subnets from remote Silverpeak
+    appliances and automatically learned local subnets.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - GET
+          - /subnets3/all
+
+    :return: Dictionary of appliance configured and learned subnets \n
+        * keyword **subnets** (`dict`): Subnet object \n
+            * keyword **count** (`int`): Count of all subnets
+            * keyword **max** (`int`): Max subnets IPv4 & IPv6, 60000
+            * keyword **entries** (`list[dict]`): List of subnet detail
+              objects \n
+                * keyword **state** (`dict`): Subnet detail object \n
+                    * keyword **version** (`int`): IP Version, e.g.
+                      ``4`` or ``6``
+                    * keyword **prefix** (`str`): Route prefix, e.g.
+                      ``10.98.98.3/32``
+                    * keyword **nextHop** (`str`): Next hop for prefix
+                    * keyword **metric** (`int`): Metric of route, e.g.
+                      ``50``
+                    * keyword **ifName** (`str`): Interface name, e.g.
+                      ``lo20000``
+                    * keyword **peerid** (`int`): Peer id, e.g.
+                      ``1894366``
+                    * keyword **saas** (`int`): SaaS value, e.g. ``0``
+                    * keyword **community** (`str`): Community string
+                    * keyword **aspath** (`str`): AS Path, e.g.
+                      ``64512,64710``
+                    * keyword **learned** (`bool`): Learned from peer
+                    * keyword **configured** (`bool`): Locally
+                      configured
+                    * keyword **advert** (`bool`): Advertise to peers
+                    * keyword **automatic** (`bool`): Automatically
+                      added by system
+                    * keyword **local** (`bool`): Local route
+                    * keyword **learnedFromIp** (`str`): IP peer route
+                      learned from
+                    * keyword **cloudApp** (`bool`): Cloud app
+                    * keyword **advert_bgp** (`bool`): Advertise to BGP
+                    * keyword **advert_ospf** (`bool`): Advertise to
+                      OSPF
+                    * keyword **learned_bgp** (`bool`): Learned from BGP
+                    * keyword **learned_ospf** (`bool`): Learned from
+                      OSPF
+                    * keyword **state** (`str`): State of route, e.g.
+                      ``UP`` or ``DOWN``
+                    * keyword **routeTag** (`str`): Tag on route, e.g.
+                      ``0``
+                    * keyword **learnFrom** (`str`): How route was
+                      learned, e.g. ``LRN_SPS_HUB`` for learned by an
+                      EdgeConnect Hub or ``LRN_SPS_SPOKE`` for learned
+                      by an EdgeConnect Spoke
+                    * keyword **resolvedNexthop** (`str`): Resolved next
+                      hop
+                    * keyword **resolvedInterface** (`str`): Resolved
+                      interface for route
+                    * keyword **peerType** (`str`): Routing peer type,
+                      e.g. ``PE`` for PE Router BGP peering
+                    * keyword **nexthopTunnel** (`str`): Next hop tunnel
+                    * keyword **networkRegionId** (`str`): Region ID and
+                      name of route, e.g. ``1,East``
+                    * keyword **subnetMessage** (`str`): Subnet message
+                    * keyword **zone_id** (`str`): Firewall zone id for
+                      route, e.g. ``0`` for Default
+                    * keyword **advOSPFTag** (`str`): Advertise OSPF tag
+                    * keyword **routeType** (`str`): Type of route e.g.
+                      ``EBGP``
+                    * keyword **saasAppName** (`str`): SaaS Application
+                      Name
+                    * keyword **adminDistance** (`int`): Admin distance
+                      of route, e.g. ``1`` for local static
+            * keyword **disabledByIPSLA** (`bool`): If routes are
+              disabled by an IPSLA in a down state
+            * keyword **metricAddedByIPSLA** (`int`): Metric added to
+              routes due to an IPSLA being in a down state
+            * keyword **peers** (`list[dict]`): List of SDWAN peer
+              objects \n
+                * keyword **index** (`str`): Peer index, e.g. ``0``
+                * keyword **peerid** (`int`): Peer id value
+                * keyword **peerName** (`str`): Hostname of peer
+                * keyword **role** (`str`): Peer role, e.g. ``0`` for
+                  ``Spoke``
+                * keyword **roleName** (`str`): Friendly name of peer
+                  role tyle, e.g. ``Spoke``
+                * keyword **metric** (`int`): Route metric
+                * keyword **peerPriority** (`int`): Peer priority value
+                * keyword **txtrans** (`int`): Last transmitted
+                  transaction count
+                * keyword **txsecs** (`int`): Time elapsed since last
+                  transmitted update
+                * keyword **rxtrans** (`int`): Last received transaction
+                  count
+                * keyword **rxsecs** (`int`): Time elapsed since last
+                  received update
+                * keyword **rxrecs** (`int`): NEEDS DESCRIPTION
+                * keyword **rxtabs** (`int`): NEEDS DESCRIPTION
+                * keyword **outOfOrderCount** (`int`): Out of order
+                  packets count, e.g. ``0``
+                * keyword **majorVersion** (`str`): Major software
+                  version, e.g. ``9`` in ``9.1.0.3``
+                * keyword **minorVersion** (`str`): Minor software
+                  version, e.g. ``1`` in ``9.1.0.3``
+                * keyword **pointVersion** (`str`): Point software
+                  version, e.g. ``0`` in ``9.1.0.3``
+                * keyword **subVersion** (`str`): Sub software version
+                  e.g. ``3`` in ``9.1.0.3``
+                * keyword **region** (`str`): Appliance region id,
+                  e.g. ``1``
+                * keyword **regionName** (`str`): Appliance region name,
+                  e.g. ``East``
+                * keyword **messageVersion** (`str`): Subnet message
+                  version, e.g. ``6``
+                * keyword **message** (`str`): Specifies Information
+                  about the supported subnet message version, e.g.
+                  ``Submsg Ver6 (>= Rel9.0 or main)``
+                * keyword **priorTxSec** (`str`): Prior Transmit second,
+                  e.g. ``1418``
+                * keyword **mainVerAndRegion** (`str`): Full software
+                  version and region ID, e.g. ``9.1.0.3 (1)``
+                * keyword **peername** (`str`): Hostname of peer
+                * keyword **prio** (`int`): Peer priority value, e.g.
+                  ``1024``
+            * keyword **moduleInfo** (`dict`): local node details
+              object \n
+                * keyword **my system id** (`str`): String system ID,
+                  e.g. ``1894366``
+                * keyword **network region** (`str`): Local appliance
+                  region name and ID, e.g. ``East (1)``
+                * keyword **network role** (`str`): Local appliance role
+                  , e.g. ``NRHub``
+                * keyword **allow management to leak** (`str`): Allow
+                  management routes to leak, boolean string e.g.
+                  ``true``
+                * keyword **last peer index** (`str`): Last peer index
+                  number, e.g. ``0``
+                * keyword **local change** (`str`): Local change id,
+                  e.g. ``0x0000``
+                * keyword **last time** (`str`): MS time since boot,
+                  e.g. ``1961072580 ms after boot``
+                * keyword **last change** (`str`): MS time since last
+                  change, e.g. ``1960554071 ms after boot``
+                * keyword **time since change** (`str`): Time since last
+                  change, e.g.  ``518 seconds``
+                * keyword **last tx trans** (`str`): Last Transmit
+                  message, e.g. ``2212``
+                * keyword **last tx rec count** (`str`): Last Transmit
+                  message received count, e.g. ``0``
+                * keyword **last tx msg count** (`str`): Last Transmit
+                  message count, e.g. ``0``
+                * keyword **rx invalid msg** (`str`): Receive invalid
+                  message count, e.g. ``0``
+                * keyword **rx unknown msg** (`str`): Receive unknown
+                  message count, e.g. ``0``
+                * keyword **IP tracking** (`str`): If IP Tracking is
+                  enabled, e.g. ``ENABLED``
+                * keyword **IP track delta** (`str`): IP Tracking delta,
+                  e.g. ``0``
+                * keyword **Active READER index** (`str`): Active reader
+                  index, e.g.  ``0``
+    :rtype: dict
+    """
+    return self._get("/subnets3/all")
+
+
+def get_appliance_subnets_all_vrfs(self) -> dict:
+    """Gets all segments configured, learned subnets from remote
+    Silverpeak appliances and automatically learned local subnets
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - GET
+          - /subnets3/all/vrfs
+
+    :return: Dictionary of appliance configured and learned subnets \n
+        * keyword **subnets** (`dict`): Subnet object \n
+            * keyword **<vrf_id>** (`dict`): Subnets in Segment/VRF \n
+                * keyword **count** (`int`): Count of all subnets
+                * keyword **max** (`int`): Max subnets IPv4 & IPv6, 60000
+                * keyword **entries** (`list[dict]`): List of subnet detail
+                  objects \n
+                    * keyword **state** (`dict`): Subnet detail object\n
+                        * keyword **version** (`int`): IP Version, e.g.
+                          ``4`` or ``6``
+                        * keyword **prefix** (`str`): Route prefix, e.g.
+                          ``10.98.98.3/32``
+                        * keyword **nextHop** (`str`): Next hop for
+                          prefix
+                        * keyword **metric** (`int`): Metric of route,
+                          e.g. ``50``
+                        * keyword **ifName** (`str`): Interface name,
+                          e.g. ``lo20000``
+                        * keyword **peerid** (`int`): Peer id, e.g.
+                          ``1894366``
+                        * keyword **saas** (`int`): SaaS value, e.g.
+                          ``0``
+                        * keyword **community** (`str`): Community
+                          string
+                        * keyword **aspath** (`str`): AS Path, e.g.
+                          ``64512,64710``
+                        * keyword **learned** (`bool`): Learned from
+                          peer
+                        * keyword **configured** (`bool`): Locally
+                          configured
+                        * keyword **advert** (`bool`): Advertise to
+                          peers
+                        * keyword **automatic** (`bool`): Automatically
+                          added by system
+                        * keyword **local** (`bool`): Local route
+                        * keyword **learnedFromIp** (`str`): IP peer
+                          route learned from
+                        * keyword **cloudApp** (`bool`): Cloud app
+                        * keyword **advert_bgp** (`bool`): Advertise to
+                          BGP
+                        * keyword **advert_ospf** (`bool`): Advertise to
+                          OSPF
+                        * keyword **learned_bgp** (`bool`): Learned from
+                          BGP
+                        * keyword **learned_ospf** (`bool`): Learned from
+                          OSPF
+                        * keyword **state** (`str`): State of route,
+                          e.g. ``UP`` or ``DOWN``
+                        * keyword **routeTag** (`str`): Tag on route,
+                          e.g. ``0``
+                        * keyword **learnFrom** (`str`): How route was
+                          learned, e.g. ``LRN_SPS_HUB`` for learned by
+                          an EdgeConnect Hub or ``LRN_SPS_SPOKE`` for
+                          learned by an EdgeConnect Spoke
+                        * keyword **resolvedNexthop** (`str`): Resolved
+                          next hop
+                        * keyword **resolvedInterface** (`str`):
+                          Resolved interface for route
+                        * keyword **peerType** (`str`): Routing peer
+                          type, e.g. ``PE`` for PE Router BGP peering
+                        * keyword **nexthopTunnel** (`str`): Next hop
+                          tunnel
+                        * keyword **networkRegionId** (`str`): Region ID
+                          and name of route, e.g. ``1,East``
+                        * keyword **subnetMessage** (`str`): Subnet
+                          message
+                        * keyword **zone_id** (`str`): Firewall zone id
+                          for route, e.g. ``0`` for Default
+                        * keyword **advOSPFTag** (`str`): Advertise OSPF tag
+                        * keyword **routeType** (`str`): Type of route
+                          e.g. ``EBGP``
+                        * keyword **saasAppName** (`str`): SaaS
+                          Application Name
+                        * keyword **adminDistance** (`int`): Admin
+                          distance of route, e.g. ``1`` for local static
+                * keyword **disabledByIPSLA** (`bool`): If routes are
+                  disabled by an IPSLA in a down state
+                * keyword **metricAddedByIPSLA** (`int`): Metric added
+                  to routes due to an IPSLA being in a down state
+            * keyword **peers** (`list[dict]`): List of SDWAN peer
+              objects \n
+                * keyword **index** (`str`): Peer index, e.g. ``0``
+                * keyword **peerid** (`int`): Peer id value
+                * keyword **peerName** (`str`): Hostname of peer
+                * keyword **role** (`str`): Peer role, e.g. ``0`` for
+                  ``Spoke``
+                * keyword **roleName** (`str`): Friendly name of peer
+                  role tyle, e.g. ``Spoke``
+                * keyword **metric** (`int`): Route metric
+                * keyword **peerPriority** (`int`): Peer priority value
+                * keyword **txtrans** (`int`): Last transmitted
+                  transaction count
+                * keyword **txsecs** (`int`): Time elapsed since last
+                  transmitted update
+                * keyword **rxtrans** (`int`): Last received transaction
+                  count
+                * keyword **rxsecs** (`int`): Time elapsed since last
+                  received update
+                * keyword **rxrecs** (`int`): NEEDS DESCRIPTION
+                * keyword **rxtabs** (`int`): NEEDS DESCRIPTION
+                * keyword **outOfOrderCount** (`int`): Out of order
+                  packets count, e.g. ``0``
+                * keyword **majorVersion** (`str`): Major software
+                  version, e.g. ``9`` in ``9.1.0.3``
+                * keyword **minorVersion** (`str`): Minor software
+                  version, e.g. ``1`` in ``9.1.0.3``
+                * keyword **pointVersion** (`str`): Point software
+                  version, e.g. ``0`` in ``9.1.0.3``
+                * keyword **subVersion** (`str`): Sub software version
+                  e.g. ``3`` in ``9.1.0.3``
+                * keyword **region** (`str`): Appliance region id,
+                  e.g. ``1``
+                * keyword **regionName** (`str`): Appliance region name,
+                  e.g. ``East``
+                * keyword **messageVersion** (`str`): Subnet message
+                  version, e.g. ``6``
+                * keyword **message** (`str`): Specifies Information
+                  about the supported subnet message version, e.g.
+                  ``Submsg Ver6 (>= Rel9.0 or main)``
+                * keyword **priorTxSec** (`str`): Prior Transmit second,
+                  e.g. ``1418``
+                * keyword **mainVerAndRegion** (`str`): Full software
+                  version and region ID, e.g. ``9.1.0.3 (1)``
+                * keyword **peername** (`str`): Hostname of peer
+                * keyword **prio** (`int`): Peer priority value, e.g.
+                  ``1024``
+            * keyword **moduleInfo** (`dict`): local node details
+              object \n
+                * keyword **my system id** (`str`): String system ID,
+                  e.g. ``1894366``
+                * keyword **network region** (`str`): Local appliance
+                  region name and ID, e.g. ``East (1)``
+                * keyword **network role** (`str`): Local appliance role
+                  , e.g. ``NRHub``
+                * keyword **allow management to leak** (`str`): Allow
+                  management routes to leak, boolean string e.g.
+                  ``true``
+                * keyword **last peer index** (`str`): Last peer index
+                  number, e.g. ``0``
+                * keyword **local change** (`str`): Local change id,
+                  e.g. ``0x0000``
+                * keyword **last time** (`str`): MS time since boot,
+                  e.g. ``1961072580 ms after boot``
+                * keyword **last change** (`str`): MS time since last
+                  change, e.g. ``1960554071 ms after boot``
+                * keyword **time since change** (`str`): Time since last
+                  change, e.g.  ``518 seconds``
+                * keyword **last tx trans** (`str`): Last Transmit
+                  message, e.g. ``2212``
+                * keyword **last tx rec count** (`str`): Last Transmit
+                  message received count, e.g. ``0``
+                * keyword **last tx msg count** (`str`): Last Transmit
+                  message count, e.g. ``0``
+                * keyword **rx invalid msg** (`str`): Receive invalid
+                  message count, e.g. ``0``
+                * keyword **rx unknown msg** (`str`): Receive unknown
+                  message count, e.g. ``0``
+                * keyword **IP tracking** (`str`): If IP Tracking is
+                  enabled, e.g. ``ENABLED``
+                * keyword **IP track delta** (`str`): IP Tracking delta,
+                  e.g. ``0``
+                * keyword **Active READER index** (`str`): Active reader
+                  index, e.g.  ``0``
+    :rtype: dict
+    """
+    return self._get("/subnets3/all/vrfs")
+
+
+def get_appliance_subnets_single_vrf(
+    self,
+    vrf_id: int,
+) -> dict:
+    """Gets specified segment configured, learned subnets from remote
+    Silverpeak appliances and automatically learned local subnets.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - GET
+          - /subnets3/all/vrfs/{vrfId}
+
+    :param vrf_id: ID Number of Segment/VRF to query for routes
+    :type vrf_id: int
+    :return: Dictionary of appliance configured and learned subnets for
+        a specified Segment/VRF \n
+        * keyword **subnets** (`dict`): Subnet object \n
+            * keyword **count** (`int`): Count of all subnets
+            * keyword **max** (`int`): Max subnets IPv4 & IPv6, 60000
+            * keyword **entries** (`list[dict]`): List of subnet detail
+              objects \n
+                * keyword **state** (`dict`): Subnet detail object \n
+                    * keyword **version** (`int`): IP Version, e.g.
+                      ``4`` or ``6``
+                    * keyword **prefix** (`str`): Route prefix, e.g.
+                      ``10.98.98.3/32``
+                    * keyword **nextHop** (`str`): Next hop for prefix
+                    * keyword **metric** (`int`): Metric of route, e.g.
+                      ``50``
+                    * keyword **ifName** (`str`): Interface name, e.g.
+                      ``lo20000``
+                    * keyword **peerid** (`int`): Peer id, e.g.
+                      ``1894366``
+                    * keyword **saas** (`int`): SaaS value, e.g. ``0``
+                    * keyword **community** (`str`): Community string
+                    * keyword **aspath** (`str`): AS Path, e.g.
+                      ``64512,64710``
+                    * keyword **learned** (`bool`): Learned from peer
+                    * keyword **configured** (`bool`): Locally
+                      configured
+                    * keyword **advert** (`bool`): Advertise to peers
+                    * keyword **automatic** (`bool`): Automatically
+                      added by system
+                    * keyword **local** (`bool`): Local route
+                    * keyword **learnedFromIp** (`str`): IP peer route
+                      learned from
+                    * keyword **cloudApp** (`bool`): Cloud app
+                    * keyword **advert_bgp** (`bool`): Advertise to BGP
+                    * keyword **advert_ospf** (`bool`): Advertise to
+                      OSPF
+                    * keyword **learned_bgp** (`bool`): Learned from BGP
+                    * keyword **learned_ospf** (`bool`): Learned from
+                      OSPF
+                    * keyword **state** (`str`): State of route, e.g.
+                      ``UP`` or ``DOWN``
+                    * keyword **routeTag** (`str`): Tag on route, e.g.
+                      ``0``
+                    * keyword **learnFrom** (`str`): How route was
+                      learned, e.g. ``LRN_SPS_HUB`` for learned by an
+                      EdgeConnect Hub or ``LRN_SPS_SPOKE`` for learned
+                      by an EdgeConnect Spoke
+                    * keyword **resolvedNexthop** (`str`): Resolved next
+                      hop
+                    * keyword **resolvedInterface** (`str`): Resolved
+                      interface for route
+                    * keyword **peerType** (`str`): Routing peer type,
+                      e.g. ``PE`` for PE Router BGP peering
+                    * keyword **nexthopTunnel** (`str`): Next hop tunnel
+                    * keyword **networkRegionId** (`str`): Region ID and
+                      name of route, e.g. ``1,East``
+                    * keyword **subnetMessage** (`str`): Subnet message
+                    * keyword **zone_id** (`str`): Firewall zone id for
+                      route, e.g. ``0`` for Default
+                    * keyword **advOSPFTag** (`str`): Advertise OSPF tag
+                    * keyword **routeType** (`str`): Type of route e.g.
+                      ``EBGP``
+                    * keyword **saasAppName** (`str`): SaaS Application
+                      Name
+                    * keyword **adminDistance** (`int`): Admin distance
+                      of route, e.g. ``1`` for local static
+            * keyword **disabledByIPSLA** (`bool`): If routes are
+              disabled by an IPSLA in a down state
+            * keyword **metricAddedByIPSLA** (`int`): Metric added to
+              routes due to an IPSLA being in a down state
+            * keyword **peers** (`list[dict]`): List of SDWAN peer
+              objects \n
+                * keyword **index** (`str`): Peer index, e.g. ``0``
+                * keyword **peerid** (`int`): Peer id value
+                * keyword **peerName** (`str`): Hostname of peer
+                * keyword **role** (`str`): Peer role, e.g. ``0`` for
+                  ``Spoke``
+                * keyword **roleName** (`str`): Friendly name of peer
+                  role tyle, e.g. ``Spoke``
+                * keyword **metric** (`int`): Route metric
+                * keyword **peerPriority** (`int`): Peer priority value
+                * keyword **txtrans** (`int`): Last transmitted
+                  transaction count
+                * keyword **txsecs** (`int`): Time elapsed since last
+                  transmitted update
+                * keyword **rxtrans** (`int`): Last received transaction
+                  count
+                * keyword **rxsecs** (`int`): Time elapsed since last
+                  received update
+                * keyword **rxrecs** (`int`): NEEDS DESCRIPTION
+                * keyword **rxtabs** (`int`): NEEDS DESCRIPTION
+                * keyword **outOfOrderCount** (`int`): Out of order
+                  packets count, e.g. ``0``
+                * keyword **majorVersion** (`str`): Major software
+                  version, e.g. ``9`` in ``9.1.0.3``
+                * keyword **minorVersion** (`str`): Minor software
+                  version, e.g. ``1`` in ``9.1.0.3``
+                * keyword **pointVersion** (`str`): Point software
+                  version, e.g. ``0`` in ``9.1.0.3``
+                * keyword **subVersion** (`str`): Sub software version
+                  e.g. ``3`` in ``9.1.0.3``
+                * keyword **region** (`str`): Appliance region id,
+                  e.g. ``1``
+                * keyword **regionName** (`str`): Appliance region name,
+                  e.g. ``East``
+                * keyword **messageVersion** (`str`): Subnet message
+                  version, e.g. ``6``
+                * keyword **message** (`str`): Specifies Information
+                  about the supported subnet message version, e.g.
+                  ``Submsg Ver6 (>= Rel9.0 or main)``
+                * keyword **priorTxSec** (`str`): Prior Transmit second,
+                  e.g. ``1418``
+                * keyword **mainVerAndRegion** (`str`): Full software
+                  version and region ID, e.g. ``9.1.0.3 (1)``
+                * keyword **peername** (`str`): Hostname of peer
+                * keyword **prio** (`int`): Peer priority value, e.g.
+                  ``1024``
+            * keyword **moduleInfo** (`dict`): local node details
+              object \n
+                * keyword **my system id** (`str`): String system ID,
+                  e.g. ``1894366``
+                * keyword **network region** (`str`): Local appliance
+                  region name and ID, e.g. ``East (1)``
+                * keyword **network role** (`str`): Local appliance role
+                  , e.g. ``NRHub``
+                * keyword **allow management to leak** (`str`): Allow
+                  management routes to leak, boolean string e.g.
+                  ``true``
+                * keyword **last peer index** (`str`): Last peer index
+                  number, e.g. ``0``
+                * keyword **local change** (`str`): Local change id,
+                  e.g. ``0x0000``
+                * keyword **last time** (`str`): MS time since boot,
+                  e.g. ``1961072580 ms after boot``
+                * keyword **last change** (`str`): MS time since last
+                  change, e.g. ``1960554071 ms after boot``
+                * keyword **time since change** (`str`): Time since last
+                  change, e.g.  ``518 seconds``
+                * keyword **last tx trans** (`str`): Last Transmit
+                  message, e.g. ``2212``
+                * keyword **last tx rec count** (`str`): Last Transmit
+                  message received count, e.g. ``0``
+                * keyword **last tx msg count** (`str`): Last Transmit
+                  message count, e.g. ``0``
+                * keyword **rx invalid msg** (`str`): Receive invalid
+                  message count, e.g. ``0``
+                * keyword **rx unknown msg** (`str`): Receive unknown
+                  message count, e.g. ``0``
+                * keyword **IP tracking** (`str`): If IP Tracking is
+                  enabled, e.g. ``ENABLED``
+                * keyword **IP track delta** (`str`): IP Tracking delta,
+                  e.g. ``0``
+                * keyword **Active READER index** (`str`): Active reader
+                  index, e.g.  ``0``
+    :rtype: dict
+    """
+    return self._get(f"/subnets3/all/vrfs/{vrf_id}")
+
+
+def get_appliance_locally_configured_subnets(self) -> dict:
+    """Get configured local subnets only.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - GET
+          - /subnets3/configured
+
+    :return: Dictionary of locally configured subnets \n
+        * keyword **prefix** (`dict`): Subnets object \n
+            * keyword **<ip_and_mask>** (`dict`): Object for this
+              prefix, e.g. key value ``10.1.1.0/24`` \n
+                * keyword **self** (`int`): Max subnets IPv4 & IPv6, 60000
+                * keyword **advert** (`bool`): If route is advertised
+                * keyword **advert_bgp** (`bool`): If route is
+                  advertised to BGP
+                * keyword **advert_ospf** (`bool`): If route is
+                  advertised to OSPF
+                * keyword **local** (`bool`): If route is locally
+                  configured
+                * keyword **nhop** (`dict`): Next hop detail object \n
+                    * keyword **<next_hop_ip>** (`dict`): Next hop \n
+                        * keyword **self** (`str`): Next hop ip address
+                        * keyword **interface** (`dict`): Next hop
+                          interface detail object \n
+                            * keyword **<interface_name>** (`dict`):
+                              interface name for next hop, e.g.
+                              ``lan0`` \n
+                            "lan0.40": {
+                                * keyword **self** (`str`): Interface
+                                  name
+                                * keyword **comment** (`str`): Comment
+                                  on route
+                                * keyword **dir** (`str`): Direction
+                                  applied, e.g. ``FROM_LAN``,
+                                  ``FROM_WAN``, ``ANY``
+                                * keyword **gms_marked** (`bool`):
+                                  If route is Orchestrator configured
+                                * keyword **metric** (`int`): Metric
+                                  of configured route
+                                * keyword **zone_id** (`int`): Firewall
+                                  zone id for route, ``65534`` for
+                                  None/Default
+    :rtype: dict
+    """
+    return self._get("/subnets3/configured")
+
+
+def update_appliance_all_locally_configured_subnets(
+    self,
+    locally_configured_subnets: dict,
+) -> bool:
+    """Set configured local subnets. Any subnets which posted but not
+    on appliance currently are added, missing subnets are removed,
+    matching subnets are updated.
+
+    .. warning::
+
+        Use :func:`~pyedgeconnect.EdgeConnect.get_appliance_locally_configured_subnets`
+        to obtain current subnets on appliance to avoid accidentally
+        deleting static routes, or use
+        :func:`~pyedgeconnect.EdgeConnect.add_appliance_locally_configured_routes`
+        to only add net-new routes to appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - POST
+          - /subnets3/configured
+
+    :param locally_configured_subnets: Dictionary of locally configured
+        subnets \n
+        * keyword **prefix** (`dict`): Subnets object \n
+            * keyword **<ip_and_mask>** (`dict`): Object for this
+              prefix, e.g. key value ``10.1.1.0/24`` \n
+                * keyword **self** (`int`): Max subnets IPv4 & IPv6, 60000
+                * keyword **advert** (`bool`): If route is advertised
+                * keyword **advert_bgp** (`bool`): If route is
+                  advertised to BGP
+                * keyword **advert_ospf** (`bool`): If route is
+                  advertised to OSPF
+                * keyword **local** (`bool`): If route is locally
+                  configured
+                * keyword **nhop** (`dict`): Next hop detail object \n
+                    * keyword **<next_hop_ip>** (`dict`): Next hop \n
+                        * keyword **self** (`str`): Next hop ip address
+                        * keyword **interface** (`dict`): Next hop
+                          interface detail object \n
+                            * keyword **<interface_name>** (`dict`):
+                              interface name for next hop, e.g.
+                              ``lan0`` \n
+                            "lan0.40": {
+                                * keyword **self** (`str`): Interface
+                                  name
+                                * keyword **comment** (`str`): Comment
+                                  on route
+                                * keyword **dir** (`str`): Direction
+                                  applied, e.g. ``FROM_LAN``,
+                                  ``FROM_WAN``, ``ANY``
+                                * keyword **gms_marked** (`bool`):
+                                  If route is Orchestrator configured
+                                * keyword **metric** (`int`): Metric
+                                  of configured route
+                                * keyword **zone_id** (`int`): Firewall
+                                  zone id for route, ``65534`` for
+                                  None/Default
+    :type locally_configured_subnets: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """  # noqa: W505, E501
+    return self._post(
+        "/subnets3/configured",
+        data=locally_configured_subnets,
+        return_type="bool",
+    )
+
+
+def get_appliance_locally_configured_subnets_single_vrf(
+    self,
+    vrf_id: int,
+) -> dict:
+    """Get configured local subnets only of specified Segment/VRF
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - GET
+          - /subnets3/configured/vrfs/{vrfId}
+
+    :param vrf_id: ID Number of Segment/VRF to query for routes
+    :type vrf_id: int
+    :return: Dictionary of locally configured subnets of specified
+        Segment/VRF \n
+        * keyword **prefix** (`dict`): Subnets object \n
+            * keyword **<ip_and_mask>** (`dict`): Object for this
+              prefix, e.g. key value ``10.1.1.0/24`` \n
+                * keyword **self** (`int`): Max subnets IPv4 & IPv6, 60000
+                * keyword **advert** (`bool`): If route is advertised
+                * keyword **advert_bgp** (`bool`): If route is
+                  advertised to BGP
+                * keyword **advert_ospf** (`bool`): If route is
+                  advertised to OSPF
+                * keyword **local** (`bool`): If route is locally
+                  configured
+                * keyword **nhop** (`dict`): Next hop detail object \n
+                    * keyword **<next_hop_ip>** (`dict`): Next hop \n
+                        * keyword **self** (`str`): Next hop ip address
+                        * keyword **interface** (`dict`): Next hop
+                          interface detail object \n
+                            * keyword **<interface_name>** (`dict`):
+                              interface name for next hop, e.g.
+                              ``lan0`` \n
+                            "lan0.40": {
+                                * keyword **self** (`str`): Interface
+                                  name
+                                * keyword **comment** (`str`): Comment
+                                  on route
+                                * keyword **dir** (`str`): Direction
+                                  applied, e.g. ``FROM_LAN``,
+                                  ``FROM_WAN``, ``ANY``
+                                * keyword **gms_marked** (`bool`):
+                                  If route is Orchestrator configured
+                                * keyword **metric** (`int`): Metric
+                                  of configured route
+                                * keyword **zone_id** (`int`): Firewall
+                                  zone id for route, ``65534`` for
+                                  None/Default
+    :rtype: dict
+    """
+    return self._get(f"/subnets3/configured/vrfs/{vrf_id}")
+
+
+def update_appliance_all_locally_configured_subnets_single_vrf(
+    self,
+    vrf_id: int,
+    locally_configured_subnets: dict,
+) -> bool:
+    """Set configured local subnets for specified Segment/VRF. Any
+    subnets which posted but not on appliance currently are added,
+    missing subnets are removed, matching subnets are updated.
+
+    .. warning::
+
+        Use :func:`~pyedgeconnect.EdgeConnect.get_appliance_locally_configured_subnets_single_vrf`
+        to obtain current subnets on appliance to avoid accidentally
+        deleting static routes
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - POST
+          - /subnets3/configured/vrfs/{vrfId}
+
+    :param vrf_id: ID Number of Segment/VRF to query for routes
+    :type vrf_id: int
+    :param locally_configured_subnets: Dictionary of locally configured
+        subnets \n
+        * keyword **prefix** (`dict`): Subnets object \n
+            * keyword **<ip_and_mask>** (`dict`): Object for this
+              prefix, e.g. key value ``10.1.1.0/24`` \n
+                * keyword **self** (`int`): Max subnets IPv4 & IPv6, 60000
+                * keyword **advert** (`bool`): If route is advertised
+                * keyword **advert_bgp** (`bool`): If route is
+                  advertised to BGP
+                * keyword **advert_ospf** (`bool`): If route is
+                  advertised to OSPF
+                * keyword **local** (`bool`): If route is locally
+                  configured
+                * keyword **nhop** (`dict`): Next hop detail object \n
+                    * keyword **<next_hop_ip>** (`dict`): Next hop \n
+                        * keyword **self** (`str`): Next hop ip address
+                        * keyword **interface** (`dict`): Next hop
+                          interface detail object \n
+                            * keyword **<interface_name>** (`dict`):
+                              interface name for next hop, e.g.
+                              ``lan0`` \n
+                            "lan0.40": {
+                                * keyword **self** (`str`): Interface
+                                  name
+                                * keyword **comment** (`str`): Comment
+                                  on route
+                                * keyword **dir** (`str`): Direction
+                                  applied, e.g. ``FROM_LAN``,
+                                  ``FROM_WAN``, ``ANY``
+                                * keyword **gms_marked** (`bool`):
+                                  If route is Orchestrator configured
+                                * keyword **metric** (`int`): Metric
+                                  of configured route
+                                * keyword **zone_id** (`int`): Firewall
+                                  zone id for route, ``65534`` for
+                                  None/Default
+    :type locally_configured_subnets: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """  # noqa: W505, E501
+    return self._post(
+        f"/subnets3/configured/vrfs/{vrf_id}",
+        data=locally_configured_subnets,
+        return_type="bool",
+    )
+
+
+def add_appliance_locally_configured_routes(
+    self,
+    locally_configured_subnets: dict,
+) -> bool:
+    """Add configured local subnets to existing routes.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - POST
+          - /subnets3/configured/addMultiple
+
+    :param locally_configured_subnets: Dictionary of locally configured
+        subnets \n
+        * keyword **prefix** (`dict`): Subnets object \n
+            * keyword **<ip_and_mask>** (`dict`): Object for this
+              prefix, e.g. key value ``10.1.1.0/24`` \n
+                * keyword **self** (`int`): Max subnets IPv4 & IPv6,
+                  60000
+                * keyword **advert** (`bool`): If route is advertised
+                * keyword **advert_bgp** (`bool`): If route is
+                  advertised to BGP
+                * keyword **advert_ospf** (`bool`): If route is
+                  advertised to OSPF
+                * keyword **local** (`bool`): If route is locally
+                  configured
+                * keyword **nhop** (`dict`): Next hop detail object \n
+                    * keyword **<next_hop_ip>** (`dict`): Next hop \n
+                        * keyword **self** (`str`): Next hop ip address
+                        * keyword **interface** (`dict`): Next hop
+                          interface detail object \n
+                            * keyword **<interface_name>** (`dict`):
+                              interface name for next hop, e.g.
+                              ``lan0`` \n
+                            "lan0.40": {
+                                * keyword **self** (`str`): Interface
+                                  name
+                                * keyword **comment** (`str`): Comment
+                                  on route
+                                * keyword **dir** (`str`): Direction
+                                  applied, e.g. ``FROM_LAN``,
+                                  ``FROM_WAN``, ``ANY``
+                                * keyword **gms_marked** (`bool`):
+                                  If route is Orchestrator configured
+                                * keyword **metric** (`int`): Metric
+                                  of configured route
+                                * keyword **zone_id** (`int`): Firewall
+                                  zone id for route, ``65534`` for
+                                  None/Default
+    :type locally_configured_subnets: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._post(
+        "/subnets3/configured/addMultiple",
+        data=locally_configured_subnets,
+        return_type="bool",
+    )
+
+
+def delete_appliance_locally_configured_routes(
+    self,
+    local_subnets_to_delete: list[dict],
+) -> bool:
+    """Delete configured local subnets specified in
+    ``local_subnets_to_delete`` parameter
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - POST
+          - /subnets3/configured/deleteMultiple
+
+    :param local_subnets_to_delete: List of locally configured subnets
+        to remove from appliance \n
+        * [`dict`]: Array of routes to remove
+            * keyword **prefix** (`str`): Prefix of route to remove
+            * keyword **nhop** (`str`): Nexthop of route to remove
+            * keyword **interface** (`str`): Interface of route to
+              remove
+    :type local_subnets_to_delete: list
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._post(
+        "/subnets3/configured/deleteMultiple",
+        data=local_subnets_to_delete,
+        return_type="bool",
+    )
+
+
+def appliance_find_preferred_route(
+    self,
+    ip_address: str,
+    in_port: str,
+    overlay_id: int,
+    segment_name: str,
+) -> dict:
+    """Find the preferred routes from appliance based on query
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - POST
+          - /routes/preferredRoute
+
+    :param ip_address: IP address to query for preferred route
+    :type ip_address: str
+    :param in_port: Incoming traffic direction. possible values are
+        ``l2w`` (from lan) or ``w2l`` (from wan) or ``self`` (for self
+        generated)
+    :type in_port: str
+    :param overlay_id: Overlay ID, use ``0`` for any overlay
+    :type overlay_id: str
+    :param segment_name: Should specify only if VRF is enabled. If left
+        as blank string the default value is ``Default``. If a Segment
+        name that does not exist is specified response will be a blank
+        dictionary.
+    :type segment_name: str
+    :return: Returns dictionary of preferred route from appliance \n
+        * keyword **passthrough** (`dict`): Contains matched passthrough
+          route details, if not passthrough will have value of
+          ``null`` \n
+            * keyword **srcMAC** (`str`): Source MAC Address
+            * keyword **destMAC** (`str`): Destination MAC Address
+            * keyword **interfaceName** (`str`): Interface name, e.g.
+              ``wan0``
+            * keyword **nexthop** (`str`): Next hop IP address
+            * keyword **vlan** (`str`): VLAN
+            * keyword **isApplianceIP** (`bool`): If IP belongs to
+              appliances
+        * keyword **swdwan** (`dict`): Contains matched sdwan route
+          details, if not sdwan will have value of ``null`` \n
+            * keyword **peerID** (`str`): Peer ID number
+            * keyword **peerName** (`str`): Hostname of SDWAN peer
+    :rtype: dict
+    """
+    data = {
+        "ipAddress": ip_address,
+        "inPort": in_port,
+        "overlayId": overlay_id,
+        "segmentName": segment_name,
+    }
+
+    return self._post(
+        "/routes/preferredRoute",
+        data=data,
+    )
+
+
+def get_appliance_routing_peers_info(self) -> list:
+    """Get appliance routing peers information
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - localSubnets
+          - GET
+          - /subnets/state/peersInfo
+
+    :return: List of appliance routing peers info \n
+        * [`dict`]: List of appliance routing peers information \n
+            * keyword **index** (`str`): Peer index, e.g. ``0``
+            * keyword **peerid** (`int`): Peer id value
+            * keyword **peerName** (`str`): Hostname of peer
+            * keyword **role** (`str`): Peer role, e.g. ``0`` for
+              ``Spoke``
+            * keyword **roleName** (`str`): Friendly name of peer
+              role tyle, e.g. ``Spoke``
+            * keyword **metric** (`int`): Route metric
+            * keyword **peerPriority** (`int`): Peer priority value
+            * keyword **txtrans** (`int`): Last transmitted
+                transaction count
+            * keyword **txsecs** (`int`): Time elapsed since last
+                transmitted update
+            * keyword **rxtrans** (`int`): Last received transaction
+                count
+            * keyword **rxsecs** (`int`): Time elapsed since last
+                received update
+            * keyword **rxrecs** (`int`): NEEDS DESCRIPTION
+            * keyword **rxtabs** (`int`): NEEDS DESCRIPTION
+            * keyword **outOfOrderCount** (`int`): Out of order
+              packets count, e.g. ``0``
+            * keyword **majorVersion** (`str`): Major software
+              version, e.g. ``9`` in ``9.1.0.3``
+            * keyword **minorVersion** (`str`): Minor software
+              version, e.g. ``1`` in ``9.1.0.3``
+            * keyword **pointVersion** (`str`): Point software
+              version, e.g. ``0`` in ``9.1.0.3``
+            * keyword **subVersion** (`str`): Sub software version
+              e.g. ``3`` in ``9.1.0.3``
+            * keyword **region** (`str`): Appliance region id,
+              e.g. ``1``
+            * keyword **regionName** (`str`): Appliance region name,
+              e.g. ``East``
+            * keyword **messageVersion** (`str`): Subnet message
+              version, e.g. ``6``
+            * keyword **message** (`str`): Specifies Information
+              about the supported subnet message version, e.g.
+              ``Submsg Ver6 (>= Rel9.0 or main)``
+            * keyword **priorTxSec** (`str`): Prior Transmit second,
+              e.g. ``1418``
+            * keyword **mainVerAndRegion** (`str`): Full software
+              version and region ID, e.g. ``9.1.0.3 (1)``
+    :rtype: dict
+    """
+    return self._get("/subnets/state/peersInfo")

--- a/pyedgeconnect/ecos/_login.py
+++ b/pyedgeconnect/ecos/_login.py
@@ -35,19 +35,28 @@ def login(
             return_type="full_response",
         )
 
-        if response is False:
+        if response.status_code == 200:
+            # get and set X-XSRF-TOKEN
+            for cookie in response.cookies:
+                if cookie.name == "edgeosCsrfToken":
+                    self.headers["X-XSRF-TOKEN"] = cookie.value
+                    return True
+                elif cookie.name == "vxoaSessionID":
+                    self.headers["vxoaSessionID"] = cookie.value
+                    return True
+                else:
+                    pass
+            # HTTP/200 without a cookie
+            self.logger.error(
+                "Login failed: HTTP 200 but no CSRF Token cookie"
+            )
+            self.logger.error(response.cookies)
+            return False
+        else:
             self.logger.error(
                 "Login failed: see above response text for details"
             )
             return False
-
-        # get and set X-XSRF-TOKEN
-        for cookie in response.cookies:
-            if cookie.name == "edgeosCsrfToken":
-                self.headers["X-XSRF-TOKEN"] = cookie.value
-            if cookie.name == "vxoaSessionID":
-                self.headers["vxoaSessionID"] = cookie.value
-        return True
 
     except Exception as ex:
         self.logger.error("login error: {}".format(type(ex)))

--- a/pyedgeconnect/ecos/_peers.py
+++ b/pyedgeconnect/ecos/_peers.py
@@ -1,0 +1,60 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# peers : Neighboring EdgeConnect Appliances
+
+
+def get_appliance_peers(
+    self,
+) -> dict:
+    """Get appliance SDWAN peers and related tunnels, including local
+    breakout passthrough tunnels
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - peers
+          - GET
+          - /peers
+
+    :return: Returns dictionary of peers and local breakout peers with
+        list of related tunnels for each \n
+        * keyword **<peer_name>** (`list[str]`): Peer object, the peer
+          name will be EdgeConnect hostname for EdgeConnect peer, or
+          Overlay name in format of ``Overlay_<OVERLAY_NAME>_Primary``
+          for local breakout \n
+            * [`str`]: List of tunnel ids connecting to this peer, e.g.
+              ``tunnel_385`` for SDWAN tunnel peer or
+              ``passThrough_320`` for local breakout
+    :rtype: dict
+    """
+    return self._get("/peers")
+
+
+def get_appliance_peers_ec_only(
+    self,
+) -> dict:
+    """Get appliance SDWAN peers and related tunnels
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - peers
+          - GET
+          - /peers/spPeers
+
+    :return: Returns dictionary of peers and local breakout peers with
+        list of related tunnels for each \n
+        * keyword **<peer_name>** (`list[str]`): Peer object, the peer
+          name will be EdgeConnect hostname for EdgeConnect peer\n
+            * [`str`]: List of tunnel ids connecting to this peer, e.g.
+              ``tunnel_385`` for SDWAN tunnel peer
+    :rtype: dict
+    """
+    return self._get("/peers/spPeers")

--- a/pyedgeconnect/ecos/_security_maps.py
+++ b/pyedgeconnect/ecos/_security_maps.py
@@ -1,0 +1,577 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# securityMaps : Manage Security Policies
+
+
+def get_appliance_security_policies(
+    self,
+) -> dict:
+    """Get appliance security policies
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - securityMaps
+          - GET
+          - /securityMaps
+
+    :return: Returns dictionary of current appliance security policy \n
+        * keyword **map1** (`dict`): Security policy object \n
+            * keyword **<zone_pair>** (`dict`): Security policy between
+              two zones, the zone pair is represented by a string of the
+              source and destination zone ids e.g. If a zone
+              ``CorpUsers`` in Default segment has an id of ``5`` and a
+              zone ``IOT`` in Default segment has an id of ``6`` the
+              zone pair would be ``5_6`` \n
+                * keyword **prio** (`dict`): Security policy rules \n
+                    * keyword **<priority_number>** (`dict`): A security
+                      rule \n
+                        * keyword **comment** (`str`):
+                        * keyword **gms_marked** (`bool`): ``True`` if
+                          rule is created by Orchestrator
+                        * keyword **match** (`dict`): Rule match
+                          criteria. Keywords are optional for desired
+                          match criteria \n
+                            * keyword **acl** (`str`): ACL name
+                            * keyword **src_ip** (`str`): Source IP
+                            * keyword **dst_ip** (`str`): Dest IP
+                            * keyword **either_ip** (`str`): Either
+                              Source or Dest IP
+                            * keyword **src_addrgrp_groups** (`str`):
+                              Source address group
+                            * keyword **dst_addrgrp_groups** (`str`):
+                              Dest address group
+                            * keyword **either_addrgrp_groups** (`str`):
+                              Either address group
+                            * keyword **protocol** (`str`): Protocol
+                            * keyword **src_port** (`str`): Source port
+                            * keyword **dst_port** (`str`): Dest port
+                            * keyword **vlan** (`str`): Vlan
+                            * keyword **application** (`str`):
+                              Application name
+                            * keyword **app_group** (`str`):
+                              Application group name
+                            * keyword **dscp** (`str`):
+                              DSCP marking
+                            * keyword **src_dns** (`str`):
+                              Source domain name
+                            * keyword **dst_dns** (`str`):
+                              Dest domain name
+                            * keyword **either_dns** (`str`):
+                              Either domain name
+                            * keyword **src_geo** (`str`):
+                              Source geo-location
+                            * keyword **dst_geo** (`str`):
+                              Dest geo-location
+                            * keyword **either_geo** (`str`):
+                              Either geo-location
+                            * keyword **src_service** (`str`):
+                              Source service
+                            * keyword **dst_service** (`str`):
+                              Destination service
+                            * keyword **either_service** (`str`):
+                              Either service
+                            * keyword **tbehavior** (`str`):
+                              Traffic behavior
+                            * keyword **overlay** (`str`):
+                              Overlay name
+                            * keyword **internet** (`str`):
+                              Internet or Fabric
+                        * keyword **misc** (`dict`): Rule enablement and
+                          logging settings \n
+                            * keyword **rule** (`str`): ``enable`` if
+                              rule is enabled,  ``disable`` if disabled
+                            * keyword **logging_priority** (`str`):
+                              Logging facility for rule
+                              ``0`` translates to ``None``,
+                              ``1`` translates to ``Emergency``,
+                              ``2`` translates to ``Alert``,
+                              ``3`` translates to ``Critical``,
+                              ``4`` translates to ``Error``,
+                              ``5`` translates to ``Warning``,
+                              ``6`` translates to ``Notice``,
+                              ``7`` translates to ``Info``,
+                              ``8`` translates to ``Debug``,
+                            * keyword **logging** (`str`): ``enable`` to
+                              enable logging, ``disable`` to disable
+                              logging
+                        * keyword **set** (`dict`): Action object \n
+                            * keyword **action** (`str`): Rule action,
+                              e.g. ``allow``, ``deny``, and ``inspect``
+                              for ids allow and inspect action
+    :rtype: dict
+    """
+    return self._get("/securityMaps")
+
+
+def configure_appliance_security_policies(
+    self,
+    security_policy: dict,
+) -> dict:
+    """Configure appliance security policies. Use
+    :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policies`
+    to retrieve policy from an existing EdgeConnect appliance to
+    reference data structure and example values.
+
+    .. note::
+        The easiest way to identify zones along with relationship to
+        Segments if Segmentation is enabled is through Orchestrator.
+        Use :func:`~pyedgeconnect.Orchestrator.get_zones_vrf_mapping`
+        which will return per-Segment/VRF the IDs and names of related
+        security zones.
+
+        :func:`~pyedgeconnect.Orchestrator.get_zones` with parameter
+        ``all_vrf_zones`` will return all Zone IDs but not the mapping
+        of which ID belongs to which Segment/VRF.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - securityMaps
+          - POST
+          - /securityMaps
+
+    :param security_policy: Full security policy to upload to
+        EdgeConnect appliance. Use
+        :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policies`
+        to retrieve policy from an existing EdgeConnect appliance to
+        reference data structure and example values
+    :type security_policy: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """  # noqa:W505
+    return self._post(
+        "/securityMaps",
+        data=security_policy,
+        return_type="bool",
+    )
+
+
+def get_appliance_security_policy_map(
+    self,
+    map_name: str = "map1",
+) -> dict:
+    """Get appliance security policy map
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - securityMaps
+          - GET
+          - /securityMaps/{mapName}
+
+    :param map_name: Name of security map to retrieve, Defaults to
+        ``map1`` as the primary map on appliances if security policy
+        is configured, Defaults to ``map1``
+    :type map_name: str, optional
+    :return: Returns dictionary of current appliance security policy \n
+        * keyword **<zone_pair>** (`dict`): Security policy between two
+          zones, the zone pair is represented by a string of the source
+          and destination zone ids e.g. If a zone ``CorpUsers`` in
+          Default segment has an id of ``5`` and a zone ``IOT`` in
+          Default segment has an id of ``6`` the zone pair would be
+          ``5_6`` \n
+            * keyword **prio** (`dict`): Security policy rules \n
+                * keyword **<priority_number>** (`dict`): A security
+                  rule \n
+                    * keyword **comment** (`str`):
+                    * keyword **gms_marked** (`bool`): ``True`` if rule
+                      is created by Orchestrator
+                    * keyword **match** (`dict`): Rule match criteria.
+                      Keywords are optional for desired match criteria\n
+                        * keyword **acl** (`str`): ACL name
+                        * keyword **src_ip** (`str`): Source IP
+                        * keyword **dst_ip** (`str`): Dest IP
+                        * keyword **either_ip** (`str`): Either Source
+                          or Dest IP
+                        * keyword **src_addrgrp_groups** (`str`): Source
+                          address group
+                        * keyword **dst_addrgrp_groups** (`str`): Dest
+                          address group
+                        * keyword **either_addrgrp_groups** (`str`):
+                          Either address group
+                        * keyword **protocol** (`str`): Protocol
+                        * keyword **src_port** (`str`): Source port
+                        * keyword **dst_port** (`str`): Dest port
+                        * keyword **vlan** (`str`): Vlan
+                        * keyword **application** (`str`): Application
+                          name
+                        * keyword **app_group** (`str`): Application
+                          group name
+                        * keyword **dscp** (`str`): DSCP marking
+                        * keyword **src_dns** (`str`): Source domain
+                          name
+                        * keyword **dst_dns** (`str`): Dest domain name
+                        * keyword **either_dns** (`str`): Either domain
+                          name
+                        * keyword **src_geo** (`str`): Source
+                          geo-location
+                        * keyword **dst_geo** (`str`): Dest geo-location
+                        * keyword **either_geo** (`str`): Either
+                          geo-location
+                        * keyword **src_service** (`str`): Source
+                          service
+                        * keyword **dst_service** (`str`): Destination
+                          service
+                        * keyword **either_service** (`str`): Either
+                          service
+                        * keyword **tbehavior** (`str`): Traffic
+                          behavior
+                        * keyword **overlay** (`str`): Overlay name
+                        * keyword **internet** (`str`): Internet or
+                          Fabric
+                    * keyword **misc** (`dict`): Rule enablement and
+                      logging settings \n
+                        * keyword **rule** (`str`): ``enable`` if rule
+                          is enabled,  ``disable`` if disabled
+                        * keyword **logging_priority** (`str`):
+                          Logging facility for rule
+                          ``0`` translates to ``None``,
+                          ``1`` translates to ``Emergency``,
+                          ``2`` translates to ``Alert``,
+                          ``3`` translates to ``Critical``,
+                          ``4`` translates to ``Error``,
+                          ``5`` translates to ``Warning``,
+                          ``6`` translates to ``Notice``,
+                          ``7`` translates to ``Info``,
+                          ``8`` translates to ``Debug``,
+                        * keyword **logging** (`str`): ``enable`` to
+                          enable logging, ``disable`` to disable logging
+                    * keyword **set** (`dict`): Action object \n
+                        * keyword **action** (`str`): Rule action,
+                          e.g. ``allow``, ``deny``, and ``inspect``
+                          for ids allow and inspect action
+    :rtype: dict
+    """
+    return self._get(f"/securityMaps/{map_name}")
+
+
+def get_appliance_security_policy_zone_pair(
+    self,
+    zone_pair: str,
+    map_name: str = "map1",
+) -> dict:
+    """Get appliance security policy map for particular zone pair.
+    Security policy between two zones, the zone pair is represented by a
+    string of the source and destination zone ids e.g. If a zone
+    ``CorpUsers`` in Default segment has an id of ``5`` and a zone
+    ``IOT`` in Default segment has an id of ``6`` the zone pair would be
+    ``5_6``.
+
+    .. note::
+        The easiest way to identify zones along with relationship to
+        Segments if Segmentation is enabled is through Orchestrator.
+        Use :func:`~pyedgeconnect.Orchestrator.get_zones_vrf_mapping`
+        which will return per-Segment/VRF the IDs and names of related
+        security zones.
+
+        :func:`~pyedgeconnect.Orchestrator.get_zones` with parameter
+        ``all_vrf_zones`` will return all Zone IDs but not the mapping
+        of which ID belongs to which Segment/VRF.
+
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - securityMaps
+          - GET
+          - /securityMaps/{mapName}/{zoneMap}
+
+    :param zone_pair: String representation of zone pairing, e.g.
+        ``5_6``
+    :type zone_pair: str
+    :param map_name: Name of security map to retrieve, Defaults to
+        ``map1`` as the primary map on appliances if security policy
+        is configured, Defaults to ``map1``
+    :type map_name: str, optional
+    :return: Returns dictionary of current appliance security policy of
+        particular zone pair \n
+        * keyword **prio** (`dict`): Security policy rules \n
+            * keyword **<priority_number>** (`dict`): A security rule \n
+                * keyword **comment** (`str`):
+                * keyword **gms_marked** (`bool`): ``True`` if rule is
+                  created by Orchestrator
+                * keyword **match** (`dict`): Rule match criteria.
+                  Keywords are optional for desired match criteria \n
+                    * keyword **acl** (`str`): ACL name
+                    * keyword **src_ip** (`str`): Source IP
+                    * keyword **dst_ip** (`str`): Dest IP
+                    * keyword **either_ip** (`str`): Either Source or
+                      Dest IP
+                    * keyword **src_addrgrp_groups** (`str`): Source
+                      address group
+                    * keyword **dst_addrgrp_groups** (`str`): Dest
+                      address group
+                    * keyword **either_addrgrp_groups** (`str`): Either
+                      address group
+                    * keyword **protocol** (`str`): Protocol
+                    * keyword **src_port** (`str`): Source port
+                    * keyword **dst_port** (`str`): Dest port
+                    * keyword **vlan** (`str`): Vlan
+                    * keyword **application** (`str`): Application name
+                    * keyword **app_group** (`str`): Application group
+                      name
+                    * keyword **dscp** (`str`): DSCP marking
+                    * keyword **src_dns** (`str`): Source domain name
+                    * keyword **dst_dns** (`str`): Dest domain name
+                    * keyword **either_dns** (`str`): Either domain name
+                    * keyword **src_geo** (`str`): Source geo-location
+                    * keyword **dst_geo** (`str`): Dest geo-location
+                    * keyword **either_geo** (`str`): Either
+                      geo-location
+                    * keyword **src_service** (`str`): Source service
+                    * keyword **dst_service** (`str`): Destination
+                      service
+                    * keyword **either_service** (`str`): Either service
+                    * keyword **tbehavior** (`str`): Traffic behavior
+                    * keyword **overlay** (`str`): Overlay name
+                    * keyword **internet** (`str`): Internet or Fabric
+                * keyword **misc** (`dict`): Rule enablement and
+                  logging settings \n
+                    * keyword **rule** (`str`): ``enable`` if rule is
+                      enabled,  ``disable`` if disabled
+                    * keyword **logging_priority** (`str`): Logging
+                      facility for rule
+                      ``0`` translates to ``None``,
+                      ``1`` translates to ``Emergency``,
+                      ``2`` translates to ``Alert``,
+                      ``3`` translates to ``Critical``,
+                      ``4`` translates to ``Error``,
+                      ``5`` translates to ``Warning``,
+                      ``6`` translates to ``Notice``,
+                      ``7`` translates to ``Info``,
+                      ``8`` translates to ``Debug``,
+                    * keyword **logging** (`str`): ``enable`` to enable
+                      logging, ``disable`` to disable logging
+                * keyword **set** (`dict`): Action object \n
+                    * keyword **action** (`str`): Rule action, e.g.
+                      ``allow``, ``deny``, and ``inspect`` for ids allow
+                      and inspect action
+    :rtype: dict
+    """
+    return self._get(f"/securityMaps/{map_name}/{zone_pair}")
+
+
+def delete_appliance_security_policy_zone_pair(
+    self,
+    zone_pair: str,
+    map_name: str = "map1",
+) -> bool:
+    """Delete zone pair from appliance security policy
+
+    .. note::
+        The easiest way to identify zones along with relationship to
+        Segments if Segmentation is enabled is through Orchestrator.
+        Use :func:`~pyedgeconnect.Orchestrator.get_zones_vrf_mapping`
+        which will return per-Segment/VRF the IDs and names of related
+        security zones.
+
+        :func:`~pyedgeconnect.Orchestrator.get_zones` with parameter
+        ``all_vrf_zones`` will return all Zone IDs but not the mapping
+        of which ID belongs to which Segment/VRF.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - securityMaps
+          - DELETE
+          - /securityMaps/{mapName}/{zoneMap}
+
+    :param zone_pair: String representation of zone pairing, e.g.
+        ``5_6``
+    :type zone_pair: str
+    :param map_name: Name of security map to retrieve, Defaults to
+        ``map1`` as the primary map on appliances if security policy
+        is configured, Defaults to ``map1``
+    :type map_name: str, optional
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._delete(
+        f"/securityMaps/{map_name}/{zone_pair}",
+        return_type="bool",
+    )
+
+
+def delete_appliance_security_policy_rule(
+    self,
+    rule_priority: int,
+    zone_pair: str,
+    map_name: str = "map1",
+) -> bool:
+    """Delete security policy rule from appliance by priority number
+
+    .. note::
+        The easiest way to identify zones along with relationship to
+        Segments if Segmentation is enabled is through Orchestrator.
+        Use :func:`~pyedgeconnect.Orchestrator.get_zones_vrf_mapping`
+        which will return per-Segment/VRF the IDs and names of related
+        security zones.
+
+        :func:`~pyedgeconnect.Orchestrator.get_zones` with parameter
+        ``all_vrf_zones`` will return all Zone IDs but not the mapping
+        of which ID belongs to which Segment/VRF.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - securityMaps
+          - DELETE
+          - /securityMaps/{mapName}/{zoneMap}/{priority}
+
+    :param rule_priority: Rule priority number to delete
+    :type rule_priority: int
+    :param zone_pair: String representation of zone pairing, e.g.
+        ``5_6``
+    :type zone_pair: str
+    :param map_name: Name of security map to retrieve, Defaults to
+        ``map1`` as the primary map on appliances if security policy
+        is configured, Defaults to ``map1``
+    :type map_name: str, optional
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._delete(
+        f"/securityMaps/{map_name}/{zone_pair}/{rule_priority}",
+        return_type="bool",
+    )
+
+
+def get_appliance_security_policy_settings(
+    self,
+) -> dict:
+    """Get appliance security policy settings for implicit drop logging
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - securityMaps
+          - GET
+          - /securityMapsSettings
+
+    :return: Returns dictionary of current appliance security policy of
+        particular zone pair \n
+        * keyword **map1** (`dict`): Security policy map \n
+            * keyword **logging** (`dict`): Logging settings object \n
+                * keyword **imp_fw_drop** (`int`): Logging level for
+                  implicit deny drops inter-zone.
+                  ``0`` translates to ``None``,
+                  ``1`` translates to ``Emergency``,
+                  ``2`` translates to ``Alert``,
+                  ``3`` translates to ``Critical``,
+                  ``4`` translates to ``Error``,
+                  ``5`` translates to ``Warning``,
+                  ``6`` translates to ``Notice``,
+                  ``7`` translates to ``Info``,
+                  ``8`` translates to ``Debug``,
+    :rtype: dict
+    """
+    return self._get("/securityMapsSettings/")
+
+
+def set_appliance_security_policy_settings(
+    self,
+    logging_level: int,
+) -> bool:
+    """Set appliance security policy settings for implicit drop logging
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - securityMaps
+          - POST
+          - /securityMapsSettings
+
+    :param logging_level: Logging level for implicit firewall drops
+        inter-zone.
+        ``0`` translates to ``None``,
+        ``1`` translates to ``Emergency``,
+        ``2`` translates to ``Alert``,
+        ``3`` translates to ``Critical``,
+        ``4`` translates to ``Error``,
+        ``5`` translates to ``Warning``,
+        ``6`` translates to ``Notice``,
+        ``7`` translates to ``Info``,
+        ``8`` translates to ``Debug``,
+    :type logging_level: int
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    data = {
+        "map1": {
+            "logging": {
+                "imp_fw_drop": logging_level,
+            }
+        }
+    }
+    return self._post(
+        "/securityMapsSettings/",
+        data=data,
+        return_type="bool",
+    )
+
+
+def get_appliance_security_policy_settings_by_map_name(
+    self,
+    map_name: str = "map1",
+) -> dict:
+    """Get appliance security policy settings for implicit drop logging
+    by specified map name
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - securityMaps
+          - GET
+          - /securityMapsSettings/{mapName}
+
+    :param map_name: Name of security map to retrieve, Defaults to
+        ``map1`` as the primary map on appliances if security policy
+        is configured, Defaults to ``map1``
+    :type map_name: str, optional
+    :return: Returns dictionary of current appliance security policy of
+        particular zone pair \n
+        * keyword **map1** (`dict`): Security policy map \n
+            * keyword **logging** (`dict`): Logging settings object \n
+                * keyword **imp_fw_drop** (`int`): Logging level for
+                  implicit deny drops inter-zone.
+                  ``0`` translates to ``None``,
+                  ``1`` translates to ``Emergency``,
+                  ``2`` translates to ``Alert``,
+                  ``3`` translates to ``Critical``,
+                  ``4`` translates to ``Error``,
+                  ``5`` translates to ``Warning``,
+                  ``6`` translates to ``Notice``,
+                  ``7`` translates to ``Info``,
+                  ``8`` translates to ``Debug``,
+    :rtype: dict
+    """
+    return self._get(f"/securityMapsSettings/{map_name}")

--- a/pyedgeconnect/ecos/_statistics.py
+++ b/pyedgeconnect/ecos/_statistics.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
 #
 # statistics : Get statistics related information
+import requests
 
 
 def get_appliance_stats_minute_range(self) -> dict:
@@ -38,7 +39,7 @@ def get_appliance_stats_minute_range(self) -> dict:
 def get_appliance_stats_minute_file(
     self,
     file: str,
-) -> dict:
+) -> requests.Response:
     """Get specific minute statistics file
 
     .. list-table::

--- a/pyedgeconnect/ecos/_third_party_tunnel.py
+++ b/pyedgeconnect/ecos/_third_party_tunnel.py
@@ -1,0 +1,698 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# thirdPartyTunnel : Third Party Tunnels
+from __future__ import annotations
+
+
+def get_appliance_3rdparty_tunnels_state(
+    self,
+    state_match: str = None,
+) -> dict:
+    """Get the current list of passthrough tunnels state information
+    like uptime and operational state
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - GET
+          - /thirdPartyTunnels/state
+
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns dictionary of tunnels with status matched from the
+        ``state_match`` parameter \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **self** (`str`): Tunnel id, e.g.
+              ``passThrough_199``
+            * keyword **oper** (`str`): Status, e.g. ``Up - Active``
+            * keyword **uptime** (`int`): Tunnel uptime in ms
+            * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1500``
+            * keyword **cur_max_bw** (`str`): Current tunnel maximum
+              bandwidth. Units in Kbps, e.g. ``50000`` for 50Mbps
+            * keyword **rem_sys_bw** (`str`): Remaining system bandwidth
+            * keyword **quiescence** (`bool`): ``True`` if tunnel is in
+              Idle state / quiescence mode
+            * keyword **remote_id** (`int`): NEEDS DESCRIPTION
+            * keyword **state_bin** (`dict`): \n
+                * keyword **tun_state** (`str`): Tunnel status,
+                  e.g. ``Up - Active``
+                * keyword **uptime** (`int`): Tunnel uptime in ms
+                * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1500``
+                * keyword **local_id** (`int`): Local ID
+                * keyword **bonded** (`bool`): Tunnel bonded state,
+                  ``False`` for passthrough tunnels
+                * keyword **ipsec_nat_addr** (`str`): ``NONE`` for
+                  passthrough tunnels
+                * keyword **ipsec_nat_port** (`str`): ``NONE`` for
+                  passthrough tunnels
+    :rtype: dict
+    """
+    path = "/thirdPartyTunnels/state"
+    if state_match is not None:
+        path += f"?state={state_match}"
+    return self._get(path)
+
+
+def get_appliance_multiple_3rdparty_tunnels_state(
+    self,
+    tunnel_list: list[str],
+) -> dict:
+    """Get the state of multiple passthrough tunnels from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - POST
+          - /thirdPartyTunnels/getStateMultiple
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns dictionary of specified tunnels queried \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **self** (`str`): Tunnel id, e.g.
+              ``passThrough_199``
+            * keyword **oper** (`str`): Status, e.g. ``Up - Active``
+            * keyword **uptime** (`int`): Tunnel uptime in ms
+            * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1500``
+            * keyword **cur_max_bw** (`str`): Current tunnel maximum
+              bandwidth. Units in Kbps, e.g. ``50000`` for 50Mbps
+            * keyword **rem_sys_bw** (`str`): Remaining system bandwidth
+            * keyword **quiescence** (`bool`): ``True`` if tunnel is in
+              Idle state / quiescence mode
+            * keyword **remote_id** (`int`): NEEDS DESCRIPTION
+            * keyword **state_bin** (`dict`): \n
+                * keyword **tun_state** (`str`): Tunnel status,
+                  e.g. ``Up - Active``
+                * keyword **uptime** (`int`): Tunnel uptime in ms
+                * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1500``
+                * keyword **local_id** (`int`): Local ID
+                * keyword **bonded** (`bool`): Tunnel bonded state,
+                  ``False`` for passthrough tunnels
+                * keyword **ipsec_nat_addr** (`str`): ``NONE`` for
+                  passthrough tunnels
+                * keyword **ipsec_nat_port** (`str`): ``NONE`` for
+                  passthrough tunnels
+    :rtype: dict
+    """
+    return self._post(
+        "/thirdPartyTunnels/getStateMultiple",
+        data=tunnel_list,
+    )
+
+
+def get_appliance_all_3rdparty_tunnel_ids(
+    self,
+    state_match: str = None,
+) -> list:
+    """Get the current list of all passthrough tunnels
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - GET
+          - /thirdPartyTunnels/allIDs
+
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns list of all tunnel ids
+        e.g. ``["passThrough_320","passThrough_321",...]``
+    :rtype: list
+    """
+    path = "/thirdPartyTunnels/allIDs"
+    if state_match is not None:
+        path += f"?state={state_match}"
+    return self._get(path)
+
+
+def get_appliance_3rdparty_tunnel_aliases(
+    self,
+    limit: int,
+    alias_match: str = None,
+    state_match: str = None,
+) -> list:
+    """Find passthrough tunnels with matching aliases on appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - GET
+          - /thirdPartyTunnels/aliases
+
+    :param limit: Max number of tunnels to return from query
+    :type limit: int
+    :param alias_match: Match text of tunnel's alias, paramter is case
+        insensitive
+    :type alias_match: str
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns list of matching tunnels with tunnel ID and alias\n
+        * [`dict`]: List of tunnel alias/id pairs \n
+            * keyword **alias** (`str`): Tunnel alias
+            * keyword **id** (`str`): Tunnel id
+    :rtype: list
+    """
+    path = f"/thirdPartyTunnels/aliases?limit={limit}"
+    if alias_match is not None:
+        path += f"&matchingAlias={alias_match}"
+    if state_match is not None:
+        path += f"&state={state_match}"
+    return self._get(path)
+
+
+def get_appliance_3rdparty_tunnels_config(
+    self,
+    state_match: str = None,
+) -> dict:
+    """Get the current list of passthrough tunnels and their
+    configuration
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - GET
+          - /thirdPartyTunnels/config
+
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns dictionary of tunnels with status matched from the
+        ``state_match`` parameter \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **admin** (`str`): Admin state of the tunnel -
+              takes two values: ``up`` or ``down``
+            * keyword **alias** (`str`): Tunnel alias/name, e.g.
+              ``AWS_<TGNM_NAME>_Primary_TGNM1`` for AWS TGNM,
+              ``<EC_HOSTNAME>_<LABEL>@<REMOTE_IP_ADDRESS>`` for Serivce
+              Orchestration endpoint,
+              ``ThirdParty_Zscaler_<LABEL>_<Primary/Secondary>_Z#`` for
+              ZScaler etc.
+            * keyword **auto_mtu** (`bool`): Determines if the tunnel
+              should have auto MTU detection
+            * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+              marking \n
+                * keyword **dscp** (`str`): DSCP marking to be used on
+                  tunnel keepalive packets to determine if tunnel remote
+                  IP address is reachable
+            * keyword **gms_marked** (`bool`): ``True`` if configured by
+              Orchestrator
+            * keyword **gre_proto** (`int`): GRE protocol in the GRE
+              header
+            * keyword **id2** (`int`): NEEDS DESCRIPTION
+            * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+              not configurable
+            * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+              tunnel
+            * keyword **presharedkey** (`str`): Tunnel preshared key
+            * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+              source port
+            * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+              destination port
+            * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+            * keyword **ipsec** (`dict`): IPSec Configuration object \n
+                * keyword **security** (`dict`): security settings \n
+                    * keyword **ah** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                    * keyword **esp** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                * keyword **mode** (`str`): e.g. ``transport``
+                * keyword **exchange_mode** (`str`): e.g. ``main``
+                * keyword **ike_aalg** (`str`): IKE Algo, e.g. ``sha1``
+                * keyword **ike_ealg** (`str`): e.g. ``default``
+                * keyword **dhgroup** (`int`): Diffie-Hellman Group,
+                  e.g. ``14``
+                * keyword **pfs** (`bool`): e.g. ``true``
+                * keyword **pfsgroup** (`str`): e.g. ``14``
+                * keyword **id_type** (`str`): e.g. ``address``
+                * keyword **ike_version** (`int`): IKE version,
+                  e.g. ``1``
+                * keyword **esn** (`bool`): e.g. ``true``
+                * keyword **id_str** (`str`): "",
+                * keyword **dpd_delay** (`int`): e.g. ``10``
+                * keyword **dpd_retry** (`int`): e.g. ``3``
+                * keyword **ike_lifetime** (`int`): e.g. ``360``
+                * keyword **lifetime** (`int`): e.g. ``360``
+                * keyword **lifebytes** (`int`): e.g. ``0``
+                * keyword **ike_id_local** (`str`): Local IKE ID
+                * keyword **ike_id_remote** (`str`): Remote IKE ID
+            * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+              manually configured, use this field and set max_bw_auto to
+              ``false``
+            * keyword **max_bw_auto** (`bool`): If the tunnel max
+              bandwidth needs to be set to auto, this field must be true
+            * keyword **max_bw_unshaped** (`bool`): false,
+            * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+            * keyword **mode** (`str`): Tunnel mode, e.g. ``ipsec_udp``,
+              ``ipsec_ip``, or ``no_encap``
+            * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1488``
+            * keyword **peername** (`str`): Tunnel peer name, often
+              blank, but for BIO local breakout will take form of e.g.
+              ``Overlay_RealTime_Primary``
+            * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+              ``auto``, ``none``
+            * keyword **pkt** (`dict`): Packet settings object \n
+                * keyword **coalesce_enable** (`bool`): Packet
+                  coalescing enabled
+                * keyword **coalesce_wait** (`int`): Packet coalescing
+                  wait timer
+                * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+                  ``enable``, ``disable``, or ``auto``
+                * keyword **fec_reset_intvl** (`int`): FEC reset
+                  interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+                * keyword **fec_max_ratio** (`int`): FEC auto maximum
+                  ration, e.g. ``10``
+                * keyword **fec_min_ratio** (`int`): FEC auto minimum
+                  ration, e.g. ``0``
+                * keyword **frag_enable** (`bool`): Enable tunnel packet
+                  fragmentation and reassembly
+                * keyword **reorder_wait** (`int`): Amount of time in ms
+                  to wait for Packet Order Correction algorithm
+            * keyword **tag_name** (`str`): Varies by tunnel type,
+              can have label id's (``25-5``), tunnel names for
+              ThirdParty name ``Zscaler_25_Primary_Z2``, or interface
+              name for local passthrough, ``lan0`` or ``wan0``
+            * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+                * keyword **fastfail** (`int`): Enable fast fail,
+                  increasing the frequency of tunnel health packets,
+                  e.g. ``0``, ``1``, or ``2``
+                * keyword **fastfail-wait-base** (`int`): 150,
+                * keyword **fastfail-wait-rtt** (`int`): 5,
+                * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+                  not configured
+                * keyword **latency** (`int`): Latency threshold, ``0``
+                  if not configured
+                * keyword **loss** (`int`): Loss threshold, ``0`` if
+                  not configured
+                * keyword **retry_count** (`int`): How many packets
+                  which are sent once per second should be missed before
+                  a tunnel is declared down, e.g. ``3``
+            * keyword **type** (`str`): NEEDS DESCRIPTION
+            * keyword **local_vrf** (`int`): Local VRF ID, Default
+              segment would be ``0``
+            * keyword **source** (`str`): Source IP address of tunnel
+            * keyword **destination** (`str`): Destination IP address of
+              tunnel, ``0.0.0.0/0`` for passthrough breakout tunnels
+    :rtype: dict
+    """
+    path = "/thirdPartyTunnels/config"
+    if state_match is not None:
+        path += f"?state={state_match}"
+    return self._get(path)
+
+
+def configure_appliance_multiple_3rdparty_tunnels(
+    self,
+    tunnel_configuration: dict,
+) -> bool:
+    """Add/modify multiple tunnels at once. Use
+    :func:`~pyedgeconnect.EdgeConnect.get_appliance_3rdparty_tunnels_config`
+    to get current tunnel configuration for example data structure.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - POST
+          - /thirdPartyTunnels/config
+
+    :param tunnel_configuration: Dictionary structure for configuring
+        multiple tunnels on EdgeConnect appliance. See response from
+        :func:`~pyedgeconnect.EdgeConnect.get_appliance_3rdparty_tunnels_config`
+        for documentation of data structure
+    :type tunnel_configuration: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._post(
+        "/thirdPartyTunnels/config",
+        data=tunnel_configuration,
+        return_type="bool",
+    )
+
+
+def get_appliance_single_3rdparty_tunnel_config(
+    self,
+    tunnel_id: str,
+) -> dict:
+    """Get specific passthrough tunnel configuration by tunnel id from
+    appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - GET
+          - /thirdPartyTunnels/config/{id}
+
+    :param tunnel_id: Tunnel id of tunnel to retrieve information for,
+        e.g. ``passThrough_385``
+    :type tunnel_id: str
+    :return: Returns dictionary of tunnel configuration for specific
+        tunnel \n
+        * keyword **admin** (`str`): Admin state of the tunnel -
+          takes two values: ``up`` or ``down``
+        * keyword **alias** (`str`): Tunnel alias/name, e.g.
+          ``AWS_<TGNM_NAME>_Primary_TGNM1`` for AWS TGNM,
+          ``<EC_HOSTNAME>_<LABEL>@<REMOTE_IP_ADDRESS>`` for Serivce
+          Orchestration endpoint,
+          ``ThirdParty_Zscaler_<LABEL>_<Primary/Secondary>_Z#`` for
+          ZScaler etc.
+        * keyword **auto_mtu** (`bool`): Determines if the tunnel
+          should have auto MTU detection
+        * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+          marking \n
+            * keyword **dscp** (`str`): DSCP marking to be used on
+              tunnel keepalive packets to determine if tunnel remote
+              IP address is reachable
+        * keyword **gms_marked** (`bool`): ``True`` if configured by
+          Orchestrator
+        * keyword **gre_proto** (`int`): GRE protocol in the GRE
+          header
+        * keyword **id2** (`int`): NEEDS DESCRIPTION
+        * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+          not configurable
+        * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+          tunnel
+        * keyword **presharedkey** (`str`): Tunnel preshared key
+        * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+          source port
+        * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+          destination port
+        * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+        * keyword **ipsec** (`dict`): IPSec Configuration object \n
+            * keyword **security** (`dict`): security settings \n
+                * keyword **ah** (`dict`): \n
+                    * keyword **algorithm** (`str`): e.g. ``sha1``
+                * keyword **esp** (`dict`): \n
+                    * keyword **algorithm** (`str`): e.g. ``sha1``
+            * keyword **mode** (`str`): e.g. ``transport``
+            * keyword **exchange_mode** (`str`): e.g. ``main``
+            * keyword **ike_aalg** (`str`): IKE Algo, e.g. ``sha1``
+            * keyword **ike_ealg** (`str`): e.g. ``default``
+            * keyword **dhgroup** (`int`): Diffie-Hellman Group,
+              e.g. ``14``
+            * keyword **pfs** (`bool`): e.g. ``true``
+            * keyword **pfsgroup** (`str`): e.g. ``14``
+            * keyword **id_type** (`str`): e.g. ``address``
+            * keyword **ike_version** (`int`): IKE version,
+              e.g. ``1``
+            * keyword **esn** (`bool`): e.g. ``true``
+            * keyword **id_str** (`str`): "",
+            * keyword **dpd_delay** (`int`): e.g. ``10``
+            * keyword **dpd_retry** (`int`): e.g. ``3``
+            * keyword **ike_lifetime** (`int`): e.g. ``360``
+            * keyword **lifetime** (`int`): e.g. ``360``
+            * keyword **lifebytes** (`int`): e.g. ``0``
+            * keyword **ike_id_local** (`str`): Local IKE ID
+            * keyword **ike_id_remote** (`str`): Remote IKE ID
+        * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+          manually configured, use this field and set max_bw_auto to
+          ``false``
+        * keyword **max_bw_auto** (`bool`): If the tunnel max
+          bandwidth needs to be set to auto, this field must be true
+        * keyword **max_bw_unshaped** (`bool`): false,
+        * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+        * keyword **mode** (`str`): Tunnel mode, e.g. ``ipsec_udp``,
+          ``ipsec_ip``, or ``no_encap``
+        * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1488``
+        * keyword **peername** (`str`): Tunnel peer name, often
+          blank, but for BIO local breakout will take form of e.g.
+          ``Overlay_RealTime_Primary``
+        * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+          ``auto``, ``none``
+        * keyword **pkt** (`dict`): Packet settings object \n
+            * keyword **coalesce_enable** (`bool`): Packet
+              coalescing enabled
+            * keyword **coalesce_wait** (`int`): Packet coalescing
+              wait timer
+            * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+              ``enable``, ``disable``, or ``auto``
+            * keyword **fec_reset_intvl** (`int`): FEC reset
+              interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+            * keyword **fec_max_ratio** (`int`): FEC auto maximum
+              ration, e.g. ``10``
+            * keyword **fec_min_ratio** (`int`): FEC auto minimum
+              ration, e.g. ``0``
+            * keyword **frag_enable** (`bool`): Enable tunnel packet
+              fragmentation and reassembly
+            * keyword **reorder_wait** (`int`): Amount of time in ms
+              to wait for Packet Order Correction algorithm
+        * keyword **tag_name** (`str`): Varies by tunnel type,
+          can have label id's (``25-5``), tunnel names for
+          ThirdParty name ``Zscaler_25_Primary_Z2``, or interface
+          name for local passthrough, ``lan0`` or ``wan0``
+        * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+            * keyword **fastfail** (`int`): Enable fast fail,
+              increasing the frequency of tunnel health packets,
+              e.g. ``0``, ``1``, or ``2``
+            * keyword **fastfail-wait-base** (`int`): 150,
+            * keyword **fastfail-wait-rtt** (`int`): 5,
+            * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+              not configured
+            * keyword **latency** (`int`): Latency threshold, ``0``
+              if not configured
+            * keyword **loss** (`int`): Loss threshold, ``0`` if
+              not configured
+            * keyword **retry_count** (`int`): How many packets
+              which are sent once per second should be missed before
+              a tunnel is declared down, e.g. ``3``
+        * keyword **type** (`str`): NEEDS DESCRIPTION
+        * keyword **local_vrf** (`int`): Local VRF ID, Default
+          segment would be ``0``
+        * keyword **source** (`str`): Source IP address of tunnel
+        * keyword **destination** (`str`): Destination IP address of
+          tunnel, ``0.0.0.0/0`` for passthrough breakout tunnels
+    :rtype: dict
+    """
+    return self._get(f"/tunnels/{tunnel_id}")
+
+
+def delete_appliance_single_3rdparty_tunnel(
+    self,
+    tunnel_id: str,
+) -> bool:
+    """Delete specific passthrough tunnel configuration by tunnel id
+    from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - DELETE
+          - /thirdPartyTunnels/config/{id}
+
+    :param tunnel_id: Tunnel id of tunnel to retrieve information for,
+        e.g. ``passThrough_385``
+    :type tunnel_id: str
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._delete(
+        f"/thirdPartyTunnels/config/{tunnel_id}",
+        return_type="bool",
+    )
+
+
+def get_appliance_multiple_3rdparty_tunnels_config(
+    self,
+    tunnel_list: list[str],
+) -> dict:
+    """Get the configuration of multiple passthrough tunnels from
+    appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - POST
+          - /thirdPartyTunnels/getMultiple
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns dictionary of specified tunnels queried \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **admin** (`str`): Admin state of the tunnel -
+              takes two values: ``up`` or ``down``
+            * keyword **alias** (`str`): Tunnel alias/name, e.g.
+              ``AWS_<TGNM_NAME>_Primary_TGNM1`` for AWS TGNM,
+              ``<EC_HOSTNAME>_<LABEL>@<REMOTE_IP_ADDRESS>`` for Serivce
+              Orchestration endpoint,
+              ``ThirdParty_Zscaler_<LABEL>_<Primary/Secondary>_Z#`` for
+              ZScaler etc.
+            * keyword **auto_mtu** (`bool`): Determines if the tunnel
+              should have auto MTU detection
+            * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+              marking \n
+                * keyword **dscp** (`str`): DSCP marking to be used on
+                  tunnel keepalive packets to determine if tunnel remote
+                  IP address is reachable
+            * keyword **gms_marked** (`bool`): ``True`` if configured by
+              Orchestrator
+            * keyword **gre_proto** (`int`): GRE protocol in the GRE
+              header
+            * keyword **id2** (`int`): NEEDS DESCRIPTION
+            * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+              not configurable
+            * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+              tunnel
+            * keyword **presharedkey** (`str`): Tunnel preshared key
+            * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+              source port
+            * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+              destination port
+            * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+            * keyword **ipsec** (`dict`): IPSec Configuration object \n
+                * keyword **security** (`dict`): security settings \n
+                    * keyword **ah** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                    * keyword **esp** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                * keyword **mode** (`str`): e.g. ``transport``
+                * keyword **exchange_mode** (`str`): e.g. ``main``
+                * keyword **ike_aalg** (`str`): IKE Algo, e.g. ``sha1``
+                * keyword **ike_ealg** (`str`): e.g. ``default``
+                * keyword **dhgroup** (`int`): Diffie-Hellman Group,
+                  e.g. ``14``
+                * keyword **pfs** (`bool`): e.g. ``true``
+                * keyword **pfsgroup** (`str`): e.g. ``14``
+                * keyword **id_type** (`str`): e.g. ``address``
+                * keyword **ike_version** (`int`): IKE version,
+                  e.g. ``1``
+                * keyword **esn** (`bool`): e.g. ``true``
+                * keyword **id_str** (`str`): "",
+                * keyword **dpd_delay** (`int`): e.g. ``10``
+                * keyword **dpd_retry** (`int`): e.g. ``3``
+                * keyword **ike_lifetime** (`int`): e.g. ``360``
+                * keyword **lifetime** (`int`): e.g. ``360``
+                * keyword **lifebytes** (`int`): e.g. ``0``
+                * keyword **ike_id_local** (`str`): Local IKE ID
+                * keyword **ike_id_remote** (`str`): Remote IKE ID
+            * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+              manually configured, use this field and set max_bw_auto to
+              ``false``
+            * keyword **max_bw_auto** (`bool`): If the tunnel max
+              bandwidth needs to be set to auto, this field must be true
+            * keyword **max_bw_unshaped** (`bool`): false,
+            * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+            * keyword **mode** (`str`): Tunnel mode, e.g. ``ipsec_udp``,
+              ``ipsec_ip``, or ``no_encap``
+            * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1488``
+            * keyword **peername** (`str`): Tunnel peer name, often
+              blank, but for BIO local breakout will take form of e.g.
+              ``Overlay_RealTime_Primary``
+            * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+              ``auto``, ``none``
+            * keyword **pkt** (`dict`): Packet settings object \n
+                * keyword **coalesce_enable** (`bool`): Packet
+                  coalescing enabled
+                * keyword **coalesce_wait** (`int`): Packet coalescing
+                  wait timer
+                * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+                  ``enable``, ``disable``, or ``auto``
+                * keyword **fec_reset_intvl** (`int`): FEC reset
+                  interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+                * keyword **fec_max_ratio** (`int`): FEC auto maximum
+                  ration, e.g. ``10``
+                * keyword **fec_min_ratio** (`int`): FEC auto minimum
+                  ration, e.g. ``0``
+                * keyword **frag_enable** (`bool`): Enable tunnel packet
+                  fragmentation and reassembly
+                * keyword **reorder_wait** (`int`): Amount of time in ms
+                  to wait for Packet Order Correction algorithm
+            * keyword **tag_name** (`str`): Varies by tunnel type,
+              can have label id's (``25-5``), tunnel names for
+              ThirdParty name ``Zscaler_25_Primary_Z2``, or interface
+              name for local passthrough, ``lan0`` or ``wan0``
+            * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+                * keyword **fastfail** (`int`): Enable fast fail,
+                  increasing the frequency of tunnel health packets,
+                  e.g. ``0``, ``1``, or ``2``
+                * keyword **fastfail-wait-base** (`int`): 150,
+                * keyword **fastfail-wait-rtt** (`int`): 5,
+                * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+                  not configured
+                * keyword **latency** (`int`): Latency threshold, ``0``
+                  if not configured
+                * keyword **loss** (`int`): Loss threshold, ``0`` if
+                  not configured
+                * keyword **retry_count** (`int`): How many packets
+                  which are sent once per second should be missed before
+                  a tunnel is declared down, e.g. ``3``
+            * keyword **type** (`str`): NEEDS DESCRIPTION
+            * keyword **local_vrf** (`int`): Local VRF ID, Default
+              segment would be ``0``
+            * keyword **source** (`str`): Source IP address of tunnel
+            * keyword **destination** (`str`): Destination IP address of
+              tunnel, ``0.0.0.0/0`` for passthrough breakout tunnels
+    :rtype: dict
+    """
+    return self._post(
+        "/thirdPartyTunnels/getMultiple",
+        data=tunnel_list,
+    )
+
+
+def delete_appliance_multiple_3rdparty_tunnels(
+    self,
+    tunnel_list: list[str],
+) -> dict:
+    """Delete multiple passthrough tunnels from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - thirdPartyTunnel
+          - POST
+          - /thirdPartyTunnels/deleteMultiple
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._post(
+        "/thirdPartyTunnels/deleteMultiple",
+        data=tunnel_list,
+    )

--- a/pyedgeconnect/ecos/_third_party_tunnel.py
+++ b/pyedgeconnect/ecos/_third_party_tunnel.py
@@ -674,7 +674,7 @@ def get_appliance_multiple_3rdparty_tunnels_config(
 def delete_appliance_multiple_3rdparty_tunnels(
     self,
     tunnel_list: list[str],
-) -> dict:
+) -> bool:
     """Delete multiple passthrough tunnels from appliance
 
     .. list-table::
@@ -695,4 +695,5 @@ def delete_appliance_multiple_3rdparty_tunnels(
     return self._post(
         "/thirdPartyTunnels/deleteMultiple",
         data=tunnel_list,
+        return_type="bool",
     )

--- a/pyedgeconnect/ecos/_tunnel.py
+++ b/pyedgeconnect/ecos/_tunnel.py
@@ -1,0 +1,1108 @@
+# MIT License
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP.
+#
+# tunnel : Underlay SDWAN Tunnels
+from __future__ import annotations
+
+
+def get_appliance_tunnels_config_and_state(
+    self,
+    state_match: str = None,
+) -> dict:
+    """Get the current list of tunnels and their configuration as well
+    as some state information like uptime and operational state
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - GET
+          - /tunnelsConfigAndState
+
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns dictionary of tunnels with status matched from the
+        ``state_match`` parameter \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **admin** (`str`): Admin state of the tunnel -
+              takes two values: ``up`` or ``down``
+            * keyword **alias** (`str`): Tunnel alias/name, e.g.
+              ``to_<REMOTE_EC_HOSTNAME>_<LOCAL_LABEL>_<REMOTE_LABEL>``
+            * keyword **auto_mtu** (`bool`): Determines if the tunnel
+              should have auto MTU detection
+            * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+              marking \n
+                * keyword **dscp** (`str`): DSCP marking to be used on
+                  tunnel keepalive packets to determine if tunnel remote
+                  IP address is reachable
+            * keyword **gms_marked** (`bool`): ``True`` if configured by
+              Orchestrator
+            * keyword **gre_proto** (`int`): GRE protocol in the GRE
+              header
+            * keyword **id2** (`int`): NEEDS DESCRIPTION
+            * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+              not configurable
+            * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+              tunnel
+            * keyword **presharedkey** (`str`): Tunnel preshared key
+            * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+              source port
+            * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+              destination port
+            * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+            * keyword **ipsec** (`dict`): IPSec Configuration object \n
+                * keyword **security** (`dict`): security settings \n
+                    * keyword **ah** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                    * keyword **esp** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                * keyword **mode** (`str`): e.g. ``transport``
+                * keyword **exchange_mode** (`str`): e.g. ``main``
+                * keyword **ike_aalg** (`str`): IKE Algo, e.g. ``sha1``
+                * keyword **ike_ealg** (`str`): e.g. ``default``
+                * keyword **dhgroup** (`int`): Diffie-Hellman Group,
+                  e.g. ``14``
+                * keyword **pfs** (`bool`): e.g. ``true``
+                * keyword **pfsgroup** (`str`): e.g. ``14``
+                * keyword **id_type** (`str`): e.g. ``address``
+                * keyword **ike_version** (`int`): IKE version,
+                  e.g. ``1``
+                * keyword **esn** (`bool`): e.g. ``true``
+                * keyword **id_str** (`str`): "",
+                * keyword **dpd_delay** (`int`): e.g. ``10``
+                * keyword **dpd_retry** (`int`): e.g. ``3``
+                * keyword **ike_lifetime** (`int`): e.g. ``360``
+                * keyword **lifetime** (`int`): e.g. ``360``
+                * keyword **lifebytes** (`int`): e.g. ``0``
+                * keyword **ike_id_local** (`str`): Local IKE ID
+                * keyword **ike_id_remote** (`str`): Remote IKE ID
+            * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+              manually configured, use this field and set max_bw_auto to
+              ``false``
+            * keyword **max_bw_auto** (`bool`): If the tunnel max
+              bandwidth needs to be set to auto, this field must be true
+            * keyword **max_bw_unshaped** (`bool`): false,
+            * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+            * keyword **mode** (`str`): Tunnel mode, e.g. ``ipsec_udp``
+            * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1488``
+            * keyword **peername** (`str`): Tunnel peer name
+            * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+              ``auto``, ``none``
+            * keyword **pkt** (`dict`): Packet settings object \n
+                * keyword **coalesce_enable** (`bool`): Packet
+                  coalescing enabled
+                * keyword **coalesce_wait** (`int`): Packet coalescing
+                  wait timer
+                * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+                  ``enable``, ``disable``, or ``auto``
+                * keyword **fec_reset_intvl** (`int`): FEC reset
+                  interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+                * keyword **fec_max_ratio** (`int`): FEC auto maximum
+                  ration, e.g. ``10``
+                * keyword **fec_min_ratio** (`int`): FEC auto minimum
+                  ration, e.g. ``0``
+                * keyword **frag_enable** (`bool`): Enable tunnel packet
+                  fragmentation and reassembly
+                * keyword **reorder_wait** (`int`): Amount of time in ms
+                  to wait for Packet Order Correction algorithm
+            * keyword **tag_name** (`str`): Label ID pairs in string of
+              ``<local_label_id>-<remote_label_id>`` e.g. if INET1 has a
+              label id of ``5`` then a tunnel between INET1 and INET1
+              would have ``tag_name`` of ``5-5``
+            * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+                * keyword **fastfail** (`int`): Enable fast fail,
+                  increasing the frequency of tunnel health packets,
+                  e.g. ``0``, ``1``, or ``2``
+                * keyword **fastfail-wait-base** (`int`): 150,
+                * keyword **fastfail-wait-rtt** (`int`): 5,
+                * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+                  not configured
+                * keyword **latency** (`int`): Latency threshold, ``0``
+                  if not configured
+                * keyword **loss** (`int`): Loss threshold, ``0`` if
+                  not configured
+                * keyword **retry_count** (`int`): How many packets
+                  which are sent once per second should be missed before
+                  a tunnel is declared down, e.g. ``3``
+            * keyword **type** (`str`): NEEDS DESCRIPTION
+            * keyword **udp_dest_port** (`int`): If the tunnel is of
+              type 'udp', the udp port to use, e.g. ``4163``
+            * keyword **udp_flows** (`int`): If tunnel mode is udp, this
+              field determines how many different udp flows are used to
+              distribute tunnel traffic, e.g. ``256``
+            * keyword **local_vrf** (`int`): Local VRF ID, Default
+              segment would be ``0``
+            * keyword **source** (`str`): Source IP address of tunnel
+            * keyword **destination** (`str`): Destination IP address of
+              tunnel
+            * keyword **uptime** (`int`): Tunnel uptime in ms
+            * keyword **status** (`str`): Tunnel status,
+              e.g. ``Up - Idle``
+            * keyword **isRediscoveringMTU** (`bool`): This flag is true
+              if auto-mtu discovery is in progress
+            * keyword **cur_max_bw** (`str`): Tunnel maximum bandwidth
+              can be lower than configured when using dynamic tunnel
+              bandwidth feature. This field shows the current tunnel
+              bandwidth. It can change every second. Units in Kbps, e.g.
+              ``50000`` for 50Mbps
+            * keyword **state_bin** (`dict`): Remote NAT \n
+                * keyword **ipsec_nat_addr** (`str`): Remote NAT address
+                * keyword **ipsec_nat_port** (`str`): Remote NAT port
+    :rtype: dict
+    """
+    path = "/tunnelsConfigAndState"
+    if state_match is not None:
+        path += f"?state={state_match}"
+    return self._get(path)
+
+
+def get_appliance_tunnels_config(
+    self,
+    state_match: str = None,
+) -> dict:
+    """Get the current list of tunnels and their configuration
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - GET
+          - /tunnels
+
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns dictionary of tunnels with status matched from the
+        ``state_match`` parameter \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **admin** (`str`): Admin state of the tunnel -
+              takes two values: ``up`` or ``down``
+            * keyword **alias** (`str`): Tunnel alias/name, e.g.
+              ``to_<REMOTE_EC_HOSTNAME>_<LOCAL_LABEL>_<REMOTE_LABEL>``
+            * keyword **auto_mtu** (`bool`): Determines if the tunnel
+              should have auto MTU detection
+            * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+              marking \n
+                * keyword **dscp** (`str`): DSCP marking to be used on
+                  tunnel keepalive packets to determine if tunnel remote
+                  IP address is reachable
+            * keyword **gms_marked** (`bool`): ``True`` if configured by
+              Orchestrator
+            * keyword **gre_proto** (`int`): GRE protocol in the GRE
+              header
+            * keyword **id2** (`int`): NEEDS DESCRIPTION
+            * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+              not configurable
+            * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+              tunnel
+            * keyword **presharedkey** (`str`): Tunnel preshared key
+            * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+              source port
+            * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+              destination port
+            * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+            * keyword **ipsec** (`dict`): IPSec Configuration object \n
+                * keyword **security** (`dict`): security settings \n
+                    * keyword **ah** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                    * keyword **esp** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                * keyword **mode** (`str`): e.g. ``transport``
+                * keyword **exchange_mode** (`str`): e.g. ``main``
+                * keyword **ike_aalg** (`str`): IKE Algo, e.g. ``sha1``
+                * keyword **ike_ealg** (`str`): e.g. ``default``
+                * keyword **dhgroup** (`int`): Diffie-Hellman Group,
+                  e.g. ``14``
+                * keyword **pfs** (`bool`): e.g. ``true``
+                * keyword **pfsgroup** (`str`): e.g. ``14``
+                * keyword **id_type** (`str`): e.g. ``address``
+                * keyword **ike_version** (`int`): IKE version,
+                  e.g. ``1``
+                * keyword **esn** (`bool`): e.g. ``true``
+                * keyword **id_str** (`str`): "",
+                * keyword **dpd_delay** (`int`): e.g. ``10``
+                * keyword **dpd_retry** (`int`): e.g. ``3``
+                * keyword **ike_lifetime** (`int`): e.g. ``360``
+                * keyword **lifetime** (`int`): e.g. ``360``
+                * keyword **lifebytes** (`int`): e.g. ``0``
+                * keyword **ike_id_local** (`str`): Local IKE ID
+                * keyword **ike_id_remote** (`str`): Remote IKE ID
+            * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+              manually configured, use this field and set max_bw_auto to
+              ``false``
+            * keyword **max_bw_auto** (`bool`): If the tunnel max
+              bandwidth needs to be set to auto, this field must be true
+            * keyword **max_bw_unshaped** (`bool`): false,
+            * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+            * keyword **mode** (`str`): Tunnel mode, e.g. ``ipsec_udp``
+            * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1488``
+            * keyword **peername** (`str`): Tunnel peer name
+            * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+              ``auto``, ``none``
+            * keyword **pkt** (`dict`): Packet settings object \n
+                * keyword **coalesce_enable** (`bool`): Packet
+                  coalescing enabled
+                * keyword **coalesce_wait** (`int`): Packet coalescing
+                  wait timer
+                * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+                  ``enable``, ``disable``, or ``auto``
+                * keyword **fec_reset_intvl** (`int`): FEC reset
+                  interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+                * keyword **fec_max_ratio** (`int`): FEC auto maximum
+                  ration, e.g. ``10``
+                * keyword **fec_min_ratio** (`int`): FEC auto minimum
+                  ration, e.g. ``0``
+                * keyword **frag_enable** (`bool`): Enable tunnel packet
+                  fragmentation and reassembly
+                * keyword **reorder_wait** (`int`): Amount of time in ms
+                  to wait for Packet Order Correction algorithm
+            * keyword **tag_name** (`str`): Label ID pairs in string of
+              ``<local_label_id>-<remote_label_id>`` e.g. if INET1 has a
+              label id of ``5`` then a tunnel between INET1 and INET1
+              would have ``tag_name`` of ``5-5``
+            * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+                * keyword **fastfail** (`int`): Enable fast fail,
+                  increasing the frequency of tunnel health packets,
+                  e.g. ``0``, ``1``, or ``2``
+                * keyword **fastfail-wait-base** (`int`): 150,
+                * keyword **fastfail-wait-rtt** (`int`): 5,
+                * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+                  not configured
+                * keyword **latency** (`int`): Latency threshold, ``0``
+                  if not configured
+                * keyword **loss** (`int`): Loss threshold, ``0`` if
+                  not configured
+                * keyword **retry_count** (`int`): How many packets
+                  which are sent once per second should be missed before
+                  a tunnel is declared down, e.g. ``3``
+            * keyword **type** (`str`): NEEDS DESCRIPTION
+            * keyword **udp_dest_port** (`int`): If the tunnel is of
+              type 'udp', the udp port to use, e.g. ``4163``
+            * keyword **udp_flows** (`int`): If tunnel mode is udp, this
+              field determines how many different udp flows are used to
+              distribute tunnel traffic, e.g. ``256``
+            * keyword **local_vrf** (`int`): Local VRF ID, Default
+              segment would be ``0``
+            * keyword **source** (`str`): Source IP address of tunnel
+            * keyword **destination** (`str`): Destination IP address of
+              tunnel
+    :rtype: dict
+    """
+    path = "/tunnels"
+    if state_match is not None:
+        path += f"?state={state_match}"
+    return self._get(path)
+
+
+def configure_appliance_all_tunnels(
+    self,
+    tunnel_configuration: dict,
+) -> bool:
+    """Add/delete/modify tunnels
+
+    .. warning::
+        This function would update all tunnels. Existing tunnel IDs will
+        be updated, New tunnel IDs will be created, missing tunnel IDs
+        will be deleted!
+
+        Use :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnels_config`
+        to get current tunnel configuration
+
+        Use :func:`~pyedgeconnect.EdgeConnect.configure_appliance_multiple_tunnels`
+        to only add net-new tunnels without having to include existing
+        tunnels and avoid accidental tunnel deletions
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - POST
+          - /tunnels
+
+
+    :param tunnel_configuration: Dictionary structure for configuring
+        tunnels on EdgeConnect appliance. See response from
+        :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnels_config`
+        for documentation of data structure
+    :type tunnel_configuration: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """  # noqa:W505,E501
+    return self._post(
+        "/tunnels",
+        data=tunnel_configuration,
+        return_type="bool",
+    )
+
+
+def get_appliance_single_tunnel_config(
+    self,
+    tunnel_id: str,
+) -> dict:
+    """Get specific tunnel configuration by tunnel id from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - GET
+          - /tunnels/{id}
+
+    :param tunnel_id: Tunnel id of tunnel to retrieve information for,
+        e.g. ``tunnel_385``
+    :type tunnel_id: str
+    :return: Returns dictionary of tunnel configuration for specific
+        tunnel \n
+        * keyword **admin** (`str`): Admin state of the tunnel -
+          takes two values: ``up`` or ``down``
+        * keyword **alias** (`str`): Tunnel alias/name, e.g.
+          ``to_<REMOTE_EC_HOSTNAME>_<LOCAL_LABEL>_<REMOTE_LABEL>``
+        * keyword **auto_mtu** (`bool`): Determines if the tunnel
+          should have auto MTU detection
+        * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+          marking \n
+            * keyword **dscp** (`str`): DSCP marking to be used on
+              tunnel keepalive packets to determine if tunnel remote
+              IP address is reachable
+        * keyword **gms_marked** (`bool`): ``True`` if configured by
+          Orchestrator
+        * keyword **gre_proto** (`int`): GRE protocol in the GRE
+          header
+        * keyword **id2** (`int`): NEEDS DESCRIPTION
+        * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+          not configurable
+        * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+          tunnel
+        * keyword **presharedkey** (`str`): Tunnel preshared key
+        * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+          source port
+        * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+          destination port
+        * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+        * keyword **ipsec** (`dict`): IPSec Configuration object \n
+            * keyword **security** (`dict`): security settings \n
+                * keyword **ah** (`dict`): \n
+                    * keyword **algorithm** (`str`): e.g. ``sha1``
+                * keyword **esp** (`dict`): \n
+                    * keyword **algorithm** (`str`): e.g. ``sha1``
+            * keyword **mode** (`str`): e.g. ``transport``
+            * keyword **exchange_mode** (`str`): e.g. ``main``
+            * keyword **ike_aalg** (`str`): IKE Algo, e.g. ``sha1``
+            * keyword **ike_ealg** (`str`): e.g. ``default``
+            * keyword **dhgroup** (`int`): Diffie-Hellman Group,
+              e.g. ``14``
+            * keyword **pfs** (`bool`): e.g. ``true``
+            * keyword **pfsgroup** (`str`): e.g. ``14``
+            * keyword **id_type** (`str`): e.g. ``address``
+            * keyword **ike_version** (`int`): IKE version,
+              e.g. ``1``
+            * keyword **esn** (`bool`): e.g. ``true``
+            * keyword **id_str** (`str`): "",
+            * keyword **dpd_delay** (`int`): e.g. ``10``
+            * keyword **dpd_retry** (`int`): e.g. ``3``
+            * keyword **ike_lifetime** (`int`): e.g. ``360``
+            * keyword **lifetime** (`int`): e.g. ``360``
+            * keyword **lifebytes** (`int`): e.g. ``0``
+            * keyword **ike_id_local** (`str`): Local IKE ID
+            * keyword **ike_id_remote** (`str`): Remote IKE ID
+        * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+          manually configured, use this field and set max_bw_auto to
+          ``false``
+        * keyword **max_bw_auto** (`bool`): If the tunnel max
+          bandwidth needs to be set to auto, this field must be true
+        * keyword **max_bw_unshaped** (`bool`): false,
+        * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+        * keyword **mode** (`str`): Tunnel mode, e.g. ``ipsec_udp``
+        * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1488``
+        * keyword **peername** (`str`): Tunnel peer name
+        * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+          ``auto``, ``none``
+        * keyword **pkt** (`dict`): Packet settings object \n
+            * keyword **coalesce_enable** (`bool`): Packet
+              coalescing enabled
+            * keyword **coalesce_wait** (`int`): Packet coalescing
+              wait timer
+            * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+              ``enable``, ``disable``, or ``auto``
+            * keyword **fec_reset_intvl** (`int`): FEC reset
+              interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+            * keyword **fec_max_ratio** (`int`): FEC auto maximum
+              ration, e.g. ``10``
+            * keyword **fec_min_ratio** (`int`): FEC auto minimum
+              ration, e.g. ``0``
+            * keyword **frag_enable** (`bool`): Enable tunnel packet
+              fragmentation and reassembly
+            * keyword **reorder_wait** (`int`): Amount of time in ms
+              to wait for Packet Order Correction algorithm
+        * keyword **tag_name** (`str`): Label ID pairs in string of
+          ``<local_label_id>-<remote_label_id>`` e.g. if INET1 has a
+          label id of ``5`` then a tunnel between INET1 and INET1
+          would have ``tag_name`` of ``5-5``
+        * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+            * keyword **fastfail** (`int`): Enable fast fail,
+              increasing the frequency of tunnel health packets,
+              e.g. ``0``, ``1``, or ``2``
+            * keyword **fastfail-wait-base** (`int`): 150,
+            * keyword **fastfail-wait-rtt** (`int`): 5,
+            * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+              not configured
+            * keyword **latency** (`int`): Latency threshold, ``0``
+              if not configured
+            * keyword **loss** (`int`): Loss threshold, ``0`` if
+              not configured
+            * keyword **retry_count** (`int`): How many packets
+              which are sent once per second should be missed before
+              a tunnel is declared down, e.g. ``3``
+        * keyword **type** (`str`): NEEDS DESCRIPTION
+        * keyword **udp_dest_port** (`int`): If the tunnel is of
+          type 'udp', the udp port to use, e.g. ``4163``
+        * keyword **udp_flows** (`int`): If tunnel mode is udp, this
+          field determines how many different udp flows are used to
+          distribute tunnel traffic, e.g. ``256``
+        * keyword **local_vrf** (`int`): Local VRF ID, Default
+          segment would be ``0``
+        * keyword **source** (`str`): Source IP address of tunnel
+        * keyword **destination** (`str`): Destination IP address of
+          tunnel
+    :rtype: dict
+    """
+    return self._get(f"/tunnels/{tunnel_id}")
+
+
+def configure_appliance_single_tunnel(
+    self,
+    tunnel_id: str,
+    tunnel_configuration: dict,
+) -> bool:
+    """Modify or Add single tunnel configuration by tunnel id
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - POST
+          - /tunnels/{id}
+
+    :param tunnel_id: Tunnel id of tunnel to retrieve information for,
+        e.g. ``tunnel_385``
+    :type tunnel_id: str
+    :param tunnel_configuration: Dictionary structure for configuring
+        tunnel on EdgeConnect appliance. See response from
+        :func:`~pyedgeconnect.EdgeConnect.get_appliance_single_tunnel_config`
+        for documentation of data structure
+    :type tunnel_configuration: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._get(
+        f"/tunnels/{tunnel_id}",
+        data=tunnel_configuration,
+        return_type="bool",
+    )
+
+
+def delete_appliance_single_tunnel(
+    self,
+    tunnel_id: str,
+) -> bool:
+    """Delete specific tunnel configuration by tunnel id from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - DELETE
+          - /tunnels/{id}
+
+    :param tunnel_id: Tunnel id of tunnel to retrieve information for,
+        e.g. ``tunnel_385``
+    :type tunnel_id: str
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._delete(
+        f"/tunnels/{tunnel_id}",
+        return_type="bool",
+    )
+
+
+def get_appliance_all_tunnel_ids(
+    self,
+    state_match: str = None,
+) -> list:
+    """Get the current list of all physical tunnels
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - GET
+          - /tunnelAllIDs
+
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns list of all tunnel ids
+        e.g. ``["tunnel_385","default","pass-through",...]``
+    :rtype: list
+    """
+    path = "/tunnelAllIDs"
+    if state_match is not None:
+        path += f"?state={state_match}"
+    return self._get(path)
+
+
+def get_appliance_tunnel_aliases(
+    self,
+    limit: int,
+    alias_match: str = None,
+    state_match: str = None,
+) -> list:
+    """Find tunnels with matching aliases on appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - GET
+          - /tunnelAliases
+
+    :param limit: Max number of tunnels to return from query
+    :type limit: int
+    :param alias_match: Match text of tunnel's alias, paramter is case
+        insensitive
+    :type alias_match: str
+    :param state_match: Regular expression used to match tunnels state,
+        e.g. ``Idle`` or ``Up`` would match all tunnels with ``status``
+        of ``Up - Idle``
+    :type state_match: str
+    :return: Returns list of matching tunnels with tunnel ID and alias\n
+        * [`dict`]: List of tunnel alias/id pairs \n
+            * keyword **alias** (`str`): Tunnel alias
+            * keyword **id** (`str`): Tunnel id
+    :rtype: list
+    """
+    path = f"/tunnelAliases?limit={limit}"
+    if alias_match is not None:
+        path += f"&matchingAlias={alias_match}"
+    if state_match is not None:
+        path += f"&state={state_match}"
+    return self._get(path)
+
+
+def get_appliance_multiple_tunnels_config(
+    self,
+    tunnel_list: list[str],
+) -> dict:
+    """Get the configuration of multiple tunnels from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - POST
+          - /getMultipleTunnels
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns dictionary of specified tunnels queried \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **admin** (`str`): Admin state of the tunnel -
+              takes two values: ``up`` or ``down``
+            * keyword **alias** (`str`): Tunnel alias/name, e.g.
+              ``to_<REMOTE_EC_HOSTNAME>_<LOCAL_LABEL>_<REMOTE_LABEL>``
+            * keyword **auto_mtu** (`bool`): Determines if the tunnel
+              should have auto MTU detection
+            * keyword **ctrl_pkt** (`dict`): Tunnel health packet
+              marking \n
+                * keyword **dscp** (`str`): DSCP marking to be used on
+                  tunnel keepalive packets to determine if tunnel remote
+                  IP address is reachable
+            * keyword **gms_marked** (`bool`): ``True`` if configured by
+              Orchestrator
+            * keyword **gre_proto** (`int`): GRE protocol in the GRE
+              header
+            * keyword **id2** (`int`): NEEDS DESCRIPTION
+            * keyword **ipsec_arc_window** (`str`): IPSec ARC Window,
+              not configurable
+            * keyword **ipsec_enable** (`bool`): ``True`` if IPSec
+              tunnel
+            * keyword **presharedkey** (`str`): Tunnel preshared key
+            * keyword **ipsec_udp_sport** (`str`): IPSec UDP tunnel
+              source port
+            * keyword **ipsec_udp_dport** (`str`): IPSec UDP tunnel
+              destination port
+            * keyword **orch_tid** (`list[int]`): NEEDS DESCRIPTION
+            * keyword **ipsec** (`dict`): IPSec Configuration object \n
+                * keyword **security** (`dict`): security settings \n
+                    * keyword **ah** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                    * keyword **esp** (`dict`): \n
+                        * keyword **algorithm** (`str`): e.g. ``sha1``
+                * keyword **mode** (`str`): e.g. ``transport``
+                * keyword **exchange_mode** (`str`): e.g. ``main``
+                * keyword **ike_aalg** (`str`): IKE Algo, e.g. ``sha1``
+                * keyword **ike_ealg** (`str`): e.g. ``default``
+                * keyword **dhgroup** (`int`): Diffie-Hellman Group,
+                  e.g. ``14``
+                * keyword **pfs** (`bool`): e.g. ``true``
+                * keyword **pfsgroup** (`str`): e.g. ``14``
+                * keyword **id_type** (`str`): e.g. ``address``
+                * keyword **ike_version** (`int`): IKE version,
+                  e.g. ``1``
+                * keyword **esn** (`bool`): e.g. ``true``
+                * keyword **id_str** (`str`): "",
+                * keyword **dpd_delay** (`int`): e.g. ``10``
+                * keyword **dpd_retry** (`int`): e.g. ``3``
+                * keyword **ike_lifetime** (`int`): e.g. ``360``
+                * keyword **lifetime** (`int`): e.g. ``360``
+                * keyword **lifebytes** (`int`): e.g. ``0``
+                * keyword **ike_id_local** (`str`): Local IKE ID
+                * keyword **ike_id_remote** (`str`): Remote IKE ID
+            * keyword **max_bw** (`int`): If the tunnel max bandwidth is
+              manually configured, use this field and set max_bw_auto to
+              ``false``
+            * keyword **max_bw_auto** (`bool`): If the tunnel max
+              bandwidth needs to be set to auto, this field must be true
+            * keyword **max_bw_unshaped** (`bool`): false,
+            * keyword **min_bw** (`int`): Tunnel minimum bandwidth
+            * keyword **mode** (`str`): Tunnel mode, e.g. ``ipsec_udp``
+            * keyword **mtu** (`str`): Tunnel MTU, e.g. ``1488``
+            * keyword **peername** (`str`): Tunnel peer name
+            * keyword **nat_mode** (`str`): Tunnel NAT mode, e.g.
+              ``auto``, ``none``
+            * keyword **pkt** (`dict`): Packet settings object \n
+                * keyword **coalesce_enable** (`bool`): Packet
+                  coalescing enabled
+                * keyword **coalesce_wait** (`int`): Packet coalescing
+                  wait timer
+                * keyword **fec_enable_str** (`str`): FEC enabled, e.g.
+                  ``enable``, ``disable``, or ``auto``
+                * keyword **fec_reset_intvl** (`int`): FEC reset
+                  interval, e.g. ``1``, ``2``, ``5``, ``10``, or ``20``
+                * keyword **fec_max_ratio** (`int`): FEC auto maximum
+                  ration, e.g. ``10``
+                * keyword **fec_min_ratio** (`int`): FEC auto minimum
+                  ration, e.g. ``0``
+                * keyword **frag_enable** (`bool`): Enable tunnel packet
+                  fragmentation and reassembly
+                * keyword **reorder_wait** (`int`): Amount of time in ms
+                  to wait for Packet Order Correction algorithm
+            * keyword **tag_name** (`str`): Label ID pairs in string of
+              ``<local_label_id>-<remote_label_id>`` e.g. if INET1 has a
+              label id of ``5`` then a tunnel between INET1 and INET1
+              would have ``tag_name`` of ``5-5``
+            * keyword **threshold** (`dict`): Tunnel fail thresholds \n
+                * keyword **fastfail** (`int`): Enable fast fail,
+                  increasing the frequency of tunnel health packets,
+                  e.g. ``0``, ``1``, or ``2``
+                * keyword **fastfail-wait-base** (`int`): 150,
+                * keyword **fastfail-wait-rtt** (`int`): 5,
+                * keyword **jitter** (`int`): Jitter threshold, ``0`` if
+                  not configured
+                * keyword **latency** (`int`): Latency threshold, ``0``
+                  if not configured
+                * keyword **loss** (`int`): Loss threshold, ``0`` if
+                  not configured
+                * keyword **retry_count** (`int`): How many packets
+                  which are sent once per second should be missed before
+                  a tunnel is declared down, e.g. ``3``
+            * keyword **type** (`str`): NEEDS DESCRIPTION
+            * keyword **udp_dest_port** (`int`): If the tunnel is of
+              type 'udp', the udp port to use, e.g. ``4163``
+            * keyword **udp_flows** (`int`): If tunnel mode is udp, this
+              field determines how many different udp flows are used to
+              distribute tunnel traffic, e.g. ``256``
+            * keyword **local_vrf** (`int`): Local VRF ID, Default
+              segment would be ``0``
+            * keyword **source** (`str`): Source IP address of tunnel
+            * keyword **destination** (`str`): Destination IP address of
+              tunnel
+    :rtype: dict
+    """
+    return self._post(
+        "/getMultipleTunnels",
+        data=tunnel_list,
+    )
+
+
+def get_appliance_multiple_tunnels_state(
+    self,
+    tunnel_list: list[str],
+) -> dict:
+    """Get the state of multiple tunnels from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - POST
+          - /getStateMultipleTunnels
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns dictionary of specified tunnels queried \n
+        * keyword **<tunnel_id>** (`dict`): Tunnel id and object \n
+            * keyword **self** (`str`): Tunnel id, e.g. ``tunnel_385``
+            * keyword **oper** (`str`): Status, e.g. ``Up - Idle``
+            * keyword **uptime** (`int`): Tunnel uptime in ms
+            * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1488``
+            * keyword **cur_max_bw** (`str`): Tunnel max bw, Kbps
+            * keyword **rem_sys_bw** (`str`): Remaining system bandwidth
+            * keyword **quiescence** (`bool`): true,
+            * keyword **remote_id** (`int`): Remote ID
+            * keyword **state_bin** (`dict`): \n
+                * keyword **tun_state** (`str`): Tunnel status,
+                  e.g. ``Up - Idle``
+                * keyword **uptime** (`int`): Tunnel uptime in ms
+                * keyword **cur_mtu** (`str`): Tunnel MTU, e.g. ``1488``
+                * keyword **local_id** (`int`): Local ID
+                * keyword **bonded** (`bool`): Tunnel bonded state
+                * keyword **ipsec_nat_addr** (`str`): Remote NAT address
+                * keyword **ipsec_nat_port** (`str`): Remote NAT port
+    :rtype: dict
+    """
+    return self._post(
+        "/getMultipleTunnels",
+        data=tunnel_list,
+    )
+
+
+def configure_appliance_multiple_tunnels(
+    self,
+    tunnel_configuration: dict,
+) -> bool:
+    """Add/modify multiple tunnels at once. Use
+    :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnels_config` to
+    get current tunnel configuration for example data structure.
+
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - POST
+          - /addMultipleTunnels
+
+
+    :param tunnel_configuration: Dictionary structure for configuring
+        multiple tunnels on EdgeConnect appliance. See response from
+        :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnels_config`
+        for documentation of data structure
+    :type tunnel_configuration: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._post(
+        "/addMultipleTunnels",
+        data=tunnel_configuration,
+        return_type="bool",
+    )
+
+
+def delete_appliance_multiple_tunnels(
+    self,
+    tunnel_list: list[str],
+) -> dict:
+    """Delete multiple tunnels from appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - POST
+          - /deleteMultipleTunnels
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._post(
+        "/deleteMultipleTunnels",
+        data=tunnel_list,
+    )
+
+
+def get_appliance_tunnel_source_endpoints(
+    self,
+) -> list:
+    """Get a list of interface IP addresses which can be used as tunnel
+    source IP addresses on this appliance.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - GET
+          - /tunnelSourceEndpoints
+
+    :return: Returns list of possible tunnel source IP addresses \n
+        * [`list[list[str,int,int]]`]: Tunnel endpoint array \n
+            * [`list[str,int,int]`]: Available tunnel endpoint array \n
+                * [0] (`str`): IP Address string, e.g. ``192.168.1.1``
+                * [1] (`int`): CIDR mask, e.g. ``30``
+                * [2] (`int`): VRF/Segment ID, e.g. ``0`` for Default
+    :rtype: list
+
+    Example response:
+
+    .. code::
+
+        [
+            [
+                "192.168.1.1",
+                30,
+                0,
+            ],
+        ]
+    """
+    return self._get("tunnelSourceEndpoints")
+
+
+def get_appliance_passthrough_tunnel_source_endpoints(
+    self,
+) -> list:
+    """Get a list of interface IP addresses which can be used as
+    passthrough tunnel source IP addresses on this appliance.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - GET
+          - /passThroughTunnelSourceEndpoints
+
+    :return: Returns list of possible passthrough tunnel source IP
+        addresses \n
+        * [`list[list[str,int,int]]`]: Tunnel endpoint array \n
+            * [`list[str,int,int]`]: Available tunnel endpoint array \n
+                * [0] (`str`): IP Address string, e.g. ``192.168.1.1``
+                * [1] (`int`): CIDR mask, e.g. ``30``
+                * [2] (`int`): VRF/Segment ID, e.g. ``0`` for Default
+    :rtype: list
+    """
+    return self._get("passThroughTunnelSourceEndpoints")
+
+
+def start_appliance_tunnel_mtu_discovery(
+    self,
+    tunnel_list: list[str],
+) -> bool:
+    """Start MTU discovery on list of of specified tunnels on appliance
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - POST
+          - /tunnelsAutoDiscoverMtu
+
+    :param tunnel_list: List of tunnel id's to query for
+    :type tunnel_list: list[str]
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    data = {"tunnels": tunnel_list}
+    return self._post(
+        "/tunnelsAutoDiscoverMtu",
+        data=data,
+        return_type="bool",
+    )
+
+
+def apply_appliance_tunnel_template(
+    self,
+    tunnel_configuration: dict,
+) -> bool:
+    """Use this method to set a group of properties across all existing
+    tunnels on the system. There is an additional property called:
+    ``apply_to_default`` which can be used to change the settings of
+    'default' tunnel as well. This allows automatically established
+    tunnels to come up with these settings.
+
+    .. important::
+
+        You can omit fields from the schema which you do not want to
+        change.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - POST
+          - /applyTunnelTemplate
+
+    :param tunnel_configuration: Dictionary structure for configuring
+        tunnel template settings on EdgeConnect appliance. \n
+
+        Example data structure:
+
+        .. code::
+
+            tunnel_configuration = {
+                "min_bw": 0,
+                "max_bw_auto": false,
+                "max_bw": 0,
+                "admin": "",
+                "ipsec_arc_window": "",
+                "mode": "",
+                "ctrl_pkt": {
+                    "dscp": ""
+                },
+                "destination": "",
+                "pkt": {
+                    "frag_enable": false,
+                    "fec_enable_str": "",
+                    "fec_reset_intvl": 0,
+                    "fec_min_ratio": 0,
+                    "fec_max_ratio": 0,
+                    "reorder_wait": 0
+                },
+                "auto_mtu": false,
+                "threshold": {
+                    "dbw_aimd": false,
+                    "dbw_rserc": false,
+                    "retry_count": 0,
+                    "fastfail": 0
+                },
+                "gre_proto": 0,
+                "udp_dest_port": 0,
+                "source": "",
+                "ipsec_enable": false,
+                "mtu": 0,
+                "options": 0,
+                "type": "",
+                "udp_flows": 0,
+                "local_vrf": 0,
+                "ipsec": {
+                    "security": {
+                    "ah": {
+                        "algorithm": ""
+                    },
+                    "esp": {
+                        "algorithm": ""
+                    }
+                    },
+                    "lifetime": 0,
+                    "lifebytes": 0,
+                    "pfsgroup": "",
+                    "pfs": false,
+                    "ike_aalg": "",
+                    "ike_ealg": "",
+                    "dhgroup": "",
+                    "dpd_delay": 0,
+                    "dpd_retry": 0,
+                    "id_type": "",
+                    "id_str": "",
+                    "exchange_mode": "",
+                    "ike_version": 0,
+                    "esn": false
+                    }
+                }
+    :type tunnel_configuration: dict
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._post(
+        "/applyTunnelTemplate",
+        data=tunnel_configuration,
+        return_type="bool",
+    )
+
+
+def set_appliance_tunnels_ipsec_psk(
+    self,
+    tunnels_psk: dict,
+) -> bool:
+    """Set the ipsec preshared key for multiple tunnels
+
+    .. important::
+
+        You can omit fields from the schema which you do not want to
+        change.
+
+    .. list-table::
+        :header-rows: 1
+
+        * - Swagger Section
+          - Method
+          - Endpoint
+        * - tunnel
+          - POST
+          - /tunnelsIpsecKey
+
+    :param tunnels_psk: Dictionary structure for configuring
+        tunnel pre-shared key settings.
+    :type tunnel_configuration: dict
+
+        Example data structure:
+
+        .. code::
+
+            tunnel_configuration = {
+                "tunnel_123": {
+                    "presharedkey": "mypresharedkeyvalue"
+                },
+            }
+
+    :return: Returns True/False based on successful call
+    :rtype: bool
+    """
+    return self._post(
+        "/tunnelsIpsecKey",
+        data=tunnels_psk,
+        return_type="bool",
+    )

--- a/pyedgeconnect/ecos/_tunnel.py
+++ b/pyedgeconnect/ecos/_tunnel.py
@@ -840,7 +840,7 @@ def configure_appliance_multiple_tunnels(
 def delete_appliance_multiple_tunnels(
     self,
     tunnel_list: list[str],
-) -> dict:
+) -> bool:
     """Delete multiple tunnels from appliance
 
     .. list-table::
@@ -861,6 +861,7 @@ def delete_appliance_multiple_tunnels(
     return self._post(
         "/deleteMultipleTunnels",
         data=tunnel_list,
+        return_type="bool",
     )
 
 

--- a/pyedgeconnect/orch/_appliance_preconfig.py
+++ b/pyedgeconnect/orch/_appliance_preconfig.py
@@ -4,6 +4,8 @@
 # appliancePreconfig : Get and apply appliance preconfigurations
 import base64
 
+import requests
+
 
 def get_all_preconfig(
     self,
@@ -490,7 +492,7 @@ def validate_preconfig(
     serial_number: str = "",
     tag: str = "",
     comment: str = "",
-):
+) -> requests.Response:
     """Runs validation on a preconfig on Orchestrator to identify errors
     within the configuration
 

--- a/pyedgeconnect/orch/_appliance_resync.py
+++ b/pyedgeconnect/orch/_appliance_resync.py
@@ -22,7 +22,7 @@ def appliance_resync(
           - Endpoint
         * - applianceResync
           - POST
-          - /applianceResyncSynchronize
+          - /applianceResync
 
     :param ne_pk_list: List of one or more appliance Network Primary
         Keys (nePk), e.g. ``["3.NE","5.NE"]``
@@ -34,6 +34,4 @@ def appliance_resync(
     """
     data = {"ids": ne_pk_list}
 
-    return self._post(
-        "/applianceResyncSynchronize", data=data, return_type="text"
-    )
+    return self._post("/applianceResync", data=data, return_type="text")

--- a/pyedgeconnect/orch/_login.py
+++ b/pyedgeconnect/orch/_login.py
@@ -69,21 +69,20 @@ def login(
         return_type="full_response",
     )
 
-    if response is False:
+    if response.status_code == 200:
+        # get and set X-XSRF-TOKEN
+        for cookie in response.cookies:
+            if cookie.name == "orchCsrfToken":
+                self.headers["X-XSRF-TOKEN"] = cookie.value
+                self.authenticated = True
+                return True
+        # HTTP/200 without a cookie
+        self.logger.error("Login failed: HTTP 200 but no CSRF Token cookie")
+        self.logger.error(response.cookies)
+        return False
+    else:
         self.logger.error("Login failed: see above response text for details")
         return False
-
-    # get and set X-XSRF-TOKEN
-    for cookie in response.cookies:
-        if cookie.name == "orchCsrfToken":
-            self.headers["X-XSRF-TOKEN"] = cookie.value
-            self.authenticated = True
-            return True
-
-    # HTTP/200 without a cookie
-    self.logger.error("Login failed: HTTP 200 but no CSRF Token cookie found")
-    self.logger.error(response.cookies)
-    return False
 
 
 def send_mfa(

--- a/pyedgeconnect/orch/_overlays.py
+++ b/pyedgeconnect/orch/_overlays.py
@@ -2,6 +2,7 @@
 # (C) Copyright 2021 Hewlett Packard Enterprise Development LP.
 #
 # overlays : Add, update, delete overlay configurations
+import requests
 
 
 def get_all_overlays_config(self) -> list:
@@ -26,7 +27,7 @@ def get_all_overlays_config(self) -> list:
 def configure_new_overlay(
     self,
     overlay_config: dict,
-) -> dict:
+) -> requests.Response:
     """Configure a new overlay on Orchestrator
 
     .. list-table::
@@ -82,7 +83,7 @@ def get_all_overlays_config_keyed(self) -> dict:
 def configure_regionalized_overlay(
     self,
     regional_overlay_config: list,
-) -> dict:
+) -> requests.Response:
     """Use this API to create an exhaustive representation of
     regionalized overlays. The body of this request should be an array
     of map which keyed by region id whose value is regional overlay
@@ -119,7 +120,7 @@ def configure_regionalized_overlay(
 def modify_regionalized_overlay(
     self,
     regional_overlay_config: list,
-) -> dict:
+) -> requests.Response:
     """Use this API to update an exhaustive representation of
     regionalized overlays. The body of this request should be a map
     keyed by overlayId whose value is a map of regionId to regional
@@ -180,7 +181,7 @@ def modify_overlay_config(
     self,
     overlay_id: int,
     overlay_config: dict,
-) -> dict:
+) -> requests.Response:
     """Use this API to update an existing overlay configuration. If you
     are using regions and have customized regional BIO per region, it
     will be overridden. To avoid this use the other PUT api which takes
@@ -201,8 +202,9 @@ def modify_overlay_config(
     :type overlay_id: int
     :param overlay_config: Full overlay configuration object
     :type overlay_config: dict
-    :return: Returns dictionary of overlay configuration
-    :rtype: dict
+    :return: Returns full response details. On successful call will
+        return newly created Overlay ID
+    :rtype: Requests.response object
     """
     return self._put(
         "/gms/overlays/config/{}".format(overlay_id),
@@ -276,7 +278,7 @@ def modify_overlay_config_for_region(
     overlay_id: int,
     region_id: int,
     overlay_config: dict,
-) -> dict:
+) -> requests.Response:
     """Use this API to update an existing overlay configuration, use
     region_id ``0`` to update global overlay configuration.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,30 @@ exclude = '''
 )/
 '''
 
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+line_length = 79
+profile = "black"
+
+[tool.tox]
+legacy_tox_ini = """
+
+[tox]
+envlist = py37, py38, py39, py310
+
+[testenv]
+deps = .[dev]
+commands =
+  pytest
+
+[testenv:format]
+commands =
+  isort pyedgeconnect/. --check-only
+  flake8 pyedgeconnect/.
+"""
+
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,12 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
         "Operating System :: OS Independent",
         "Natural Language :: English",
     ],
-    keywords="silver peak, silverpeak, silver peak python, aruba edge connect, edge connect",
+    keywords="silverpeak, silverpeak python, aruba edgeconnect, edgeconnect",
     packages=find_packages(),
     package_dir={"pyedgeconnect": "pyedgeconnect"},
     python_requires=">=3.7, <4",
@@ -52,10 +53,11 @@ setup(
             "isort",
             "sphinx",
             "sphinx_rtd_theme",
+            "pytest",
         ],
     },
     project_urls={
-        "Bug Reports": "https://github.com/SPOpenSource/edgeconnect-python/issues",
+        "Bug Reports": "https://github.com/SPOpenSource/edgeconnect-python/issues",  # noqa E501
         "Source": "https://github.com/SPOpenSource/edgeconnect-python/",
     },
 )

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,6 @@
+from pyedgeconnect import EdgeConnect, Orchestrator  # noqa F401
+
+
+# def test_pass():
+def test_package_import():
+    assert True


### PR DESCRIPTION
0.15.2-a1 -- 2022-07-29
-----------------------


🚀 Features
~~~~~~~~~~~~~

- New code example: **upload security policy** - Upload Firewall
  Security Policies to an appliance or create a new Template Group to
  be assigned to appliances

  - Overview: :doc:`/examples/upload_security_policy`
  - Code: `upload_security_policy <https://github.com/SPOpenSource/edgeconnect-python/tree/main/examples/upload_security_policy>`_

- Updated logging messages (when using ``log_console`` and ``log_file``
  parameters for EdgeConnect and Orchestrator) to include base Orch FQDN
  or ECOS FQDN to be clear when logging statements across different
  instances in a single script.


Added the following EdgeConnect functions from Swagger:

from .ecos._alarm
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_alarms`
  - :func:`~pyedgeconnect.EdgeConnect.acknowledge_appliance_alarms`
  - :func:`~pyedgeconnect.EdgeConnect.clear_appliance_alarms`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_alarm_descriptions`
  - :func:`~pyedgeconnect.EdgeConnect.add_note_appliance_alarms`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_alarms`

from .ecos._bonded_tunnel
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnels_state`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_bonded_tunnels_state`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_all_bonded_tunnel_ids`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnel_aliases`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnels_config`
  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_all_bonded_tunnels`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_single_bonded_tunnel_config`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_single_bonded_tunnel`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_bonded_tunnels_config`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_multiple_bonded_tunnels`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_bonded_tunnel_live_view_info`

from .ecos._cli
  - :func:`~pyedgeconnect.EdgeConnect.perform_appliance_cli_command`
  - :func:`~pyedgeconnect.EdgeConnect.perform_appliance_multiple_cli_command`

from .ecos._deployment
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_deployment`

from .ecos._local_subnets
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_subnets`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_subnets_all_vrfs`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_subnets_single_vrf`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_locally_configured_subnets`
  - :func:`~pyedgeconnect.EdgeConnect.update_appliance_all_locally_configured_subnets`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_locally_configured_subnets_single_vrf`
  - :func:`~pyedgeconnect.EdgeConnect.update_appliance_all_locally_configured_subnets_single_vrf`
  - :func:`~pyedgeconnect.EdgeConnect.add_appliance_locally_configured_routes`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_locally_configured_routes`
  - :func:`~pyedgeconnect.EdgeConnect.appliance_find_preferred_route`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_routing_peers_info`

from .ecos._peers
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_peers`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_peers_ec_only`

from .ecos._security_maps
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policies`
  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_security_policies`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policy_map`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policy_zone_pair`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_security_policy_zone_pair`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_security_policy_rule`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policy_settings`
  - :func:`~pyedgeconnect.EdgeConnect.set_appliance_security_policy_settings`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_security_policy_settings_by_map_name`

from .ecos._third_party_tunnel
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_3rdparty_tunnels_state`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_3rdparty_tunnels_state`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_all_3rdparty_tunnel_ids`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_3rdparty_tunnel_aliases`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_3rdparty_tunnels_config`
  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_multiple_3rdparty_tunnels`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_single_3rdparty_tunnel_config`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_single_3rdparty_tunnel`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_3rdparty_tunnels_config`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_multiple_3rdparty_tunnels`

from .ecos._tunnel
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnels_config_and_state`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnels_config`
  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_all_tunnels`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_single_tunnel_config`
  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_single_tunnel`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_single_tunnel`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_all_tunnel_ids`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnel_aliases`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_tunnels_config`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_multiple_tunnels_state`
  - :func:`~pyedgeconnect.EdgeConnect.configure_appliance_multiple_tunnels`
  - :func:`~pyedgeconnect.EdgeConnect.delete_appliance_multiple_tunnels`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_tunnel_source_endpoints`
  - :func:`~pyedgeconnect.EdgeConnect.get_appliance_passthrough_tunnel_source_endpoints`
  - :func:`~pyedgeconnect.EdgeConnect.start_appliance_tunnel_mtu_discovery`
  - :func:`~pyedgeconnect.EdgeConnect.apply_appliance_tunnel_template`
  - :func:`~pyedgeconnect.EdgeConnect.set_appliance_tunnels_ipsec_psk`

~~~~~~~~~~~~~~


🐛 Bug Fixes
~~~~~~~~~~~~~~

- `#10 <https://github.com/SPOpenSource/edgeconnect-python/issues/10>`_ -
  :func:`~pyedgeconnect.Orchestrator.login` and
  :func:`~pyedgeconnect.EdgeConnect.login` returned ``True`` even when
  login failed
- `#11 <https://github.com/SPOpenSource/edgeconnect-python/issues/11>`_ -
  :func:`~pyedgeconnect.Orchestrator.appliance_resync` had incorrect
  endpoint of ``/applianceResyncSynchronize``, corrected to
  ``/applianceResync``
- `#12 <https://github.com/SPOpenSource/edgeconnect-python/issues/12>`_ -
  The preconfig generator example code had the option to look for a
  column for appliance serial number to match preconfig to, however,
  didn't include that information when creating the preconfig on
  Orchestrator as the parameter wasn't specified.
- `#13 <https://github.com/SPOpenSource/edgeconnect-python/issues/13>`_ -
  Corrected return type-hint for methods that use `return_type="full_response"`
  with hint of requests.Response object rather than `dict`

~~~~~~~~~~~~~~


🧰 Maintenance / Other
~~~~~~~~~~~~~~~~~~~~~~~

Introduced initial automated tox testing for Python 3.7, 3.8, 3.9, 3.10
- run pytest tests

additional `testenv:format` environment
- Check isort for imported packages
- Check flake8

~~~~~~~~~~~~~~


🐛 Known Issues
~~~~~~~~~~~~~~~

.. warning::

  The following two functions for the _ip_objects submodule exprience
  errors at this time. These function do work in the Orchestrator UI:
  :func:`~pyedgeconnect.Orchestrator.bulk_upload_address_group` and
  :func:`~pyedgeconnect.Orchestrator.bulk_upload_service_group`